### PR TITLE
⚡ Optimize PdfScanner black-and-white conversion

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.11.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfScanner.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfScanner.kt
@@ -331,27 +331,34 @@ class PdfScanner(private val context: Context) {
      */
     private fun convertToBlackAndWhite(source: Bitmap): Bitmap {
         val grayscale = convertToGrayscale(source)
-        val result = Bitmap.createBitmap(grayscale.width, grayscale.height, Bitmap.Config.ARGB_8888)
-        
+        val width = grayscale.width
+        val height = grayscale.height
+        val result = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+        val pixels = IntArray(width * height)
+        grayscale.getPixels(pixels, 0, width, 0, 0, width, height)
+
         val threshold = 128
-        
-        for (y in 0 until grayscale.height) {
-            for (x in 0 until grayscale.width) {
-                val pixel = grayscale.getPixel(x, y)
-                val gray = android.graphics.Color.red(pixel)
-                val newColor = if (gray > threshold) {
-                    android.graphics.Color.WHITE
-                } else {
-                    android.graphics.Color.BLACK
-                }
-                result.setPixel(x, y, newColor)
+
+        for (i in pixels.indices) {
+            val pixel = pixels[i]
+            // For grayscale images, R=G=B. Extracting red component is sufficient.
+            // Using bitwise operations for performance: (pixel >> 16) & 0xFF
+            val gray = (pixel shr 16) and 0xFF
+
+            pixels[i] = if (gray > threshold) {
+                android.graphics.Color.WHITE
+            } else {
+                android.graphics.Color.BLACK
             }
         }
-        
+
+        result.setPixels(pixels, 0, width, 0, 0, width, height)
+
         if (grayscale != source) {
             grayscale.recycle()
         }
-        
+
         return result
     }
     

--- a/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfScannerTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfScannerTest.kt
@@ -1,0 +1,79 @@
+package com.yourname.pdftoolkit.domain.operations
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.lang.reflect.Method
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], manifest = Config.NONE)
+class PdfScannerTest {
+
+    @Test
+    fun verifyConvertToBlackAndWhiteLogic() {
+        // Setup - 100x100 image
+        val width = 100
+        val height = 100
+        val source = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+        // Fill with specific pattern (Gradient)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val v = (x + y) % 256
+                source.setPixel(x, y, Color.rgb(v, v, v))
+            }
+        }
+
+        // Expected result using legacy logic (trusted reference)
+        val expected = legacyConversion(source)
+
+        // Actual result using reflection on PdfScanner
+        val context = RuntimeEnvironment.getApplication()
+        val scanner = PdfScanner(context)
+
+        val method: Method = PdfScanner::class.java.getDeclaredMethod("convertToBlackAndWhite", Bitmap::class.java)
+        method.isAccessible = true
+        val actual = method.invoke(scanner, source) as Bitmap
+
+        // Verify
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                assertEquals("Pixel at $x, $y", expected.getPixel(x, y), actual.getPixel(x, y))
+            }
+        }
+    }
+
+    /**
+     * Reference implementation of the legacy pixel-by-pixel logic to ensure
+     * the optimized version maintains exact behavior.
+     */
+    private fun legacyConversion(source: Bitmap): Bitmap {
+        val width = source.width
+        val height = source.height
+        val grayscale = source // Input is already grayscale in this test context
+        val result = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+        val threshold = 128
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val pixel = grayscale.getPixel(x, y)
+                // Extract red component (works for grayscale where R=G=B)
+                val gray = (pixel shr 16) and 0xFF
+                val newColor = if (gray > threshold) {
+                    android.graphics.Color.WHITE
+                } else {
+                    android.graphics.Color.BLACK
+                }
+                result.setPixel(x, y, newColor)
+            }
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
Optimized the `convertToBlackAndWhite` method in `PdfScanner.kt` to improve performance.

**Changes:**
- Replaced the nested loop calling `getPixel`/`setPixel` (which incurs heavy JNI overhead on Android) with `getPixels`/`setPixels` to process the entire bitmap buffer in an integer array.
- Used bitwise operations `(pixel >> 16) & 0xFF` instead of `Color.red()` for slightly better performance.
- Added `testImplementation("org.robolectric:robolectric:4.11.1")` to `app/build.gradle.kts`.
- Added `PdfScannerTest.kt` to verify that the optimized implementation produces exactly the same binary image output as the legacy implementation, ensuring no regressions.

**Performance:**
- While Robolectric benchmarks are limited (as they run on JVM without JNI overhead), the algorithmic change is a standard Android optimization known to provide orders of magnitude speedup for image processing.
- Verified correctness via `PdfScannerTest`.

---
*PR created automatically by Jules for task [4989321557004637740](https://jules.google.com/task/4989321557004637740) started by @Karna14314*