### PR TITLE
⚡ Bolt: PdfViewer Stability & Logic Fix

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -1,0 +1,220 @@
+package com.yourname.pdftoolkit.ui.screens
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.util.Log
+import android.util.LruCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
+import com.tom_roush.pdfbox.pdmodel.PDDocument
+import com.tom_roush.pdfbox.rendering.PDFRenderer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+// Moved from PdfViewerScreen.kt
+enum class AnnotationTool(val displayName: String) {
+    NONE("Select"),
+    HIGHLIGHTER("Highlighter"),
+    MARKER("Marker"),
+    UNDERLINE("Underline")
+}
+
+data class AnnotationStroke(
+    val pageIndex: Int,
+    val tool: AnnotationTool,
+    val color: Color,
+    val points: List<Offset>,
+    val strokeWidth: Float
+)
+
+// Sealed class for mutually exclusive tool states
+sealed class PdfTool {
+    object None : PdfTool()
+    object Search : PdfTool()
+    object Edit : PdfTool() // General Edit mode (shows annotation toolbar)
+}
+
+sealed class PdfViewerUiState {
+    object Idle : PdfViewerUiState()
+    object Loading : PdfViewerUiState()
+    data class Error(val message: String) : PdfViewerUiState()
+    data class Loaded(val totalPages: Int) : PdfViewerUiState()
+}
+
+class PdfViewerViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow<PdfViewerUiState>(PdfViewerUiState.Idle)
+    val uiState: StateFlow<PdfViewerUiState> = _uiState.asStateFlow()
+
+    private val _toolState = MutableStateFlow<PdfTool>(PdfTool.None)
+    val toolState: StateFlow<PdfTool> = _toolState.asStateFlow()
+
+    private val _selectedAnnotationTool = MutableStateFlow(AnnotationTool.NONE)
+    val selectedAnnotationTool: StateFlow<AnnotationTool> = _selectedAnnotationTool.asStateFlow()
+
+    private val _selectedColor = MutableStateFlow(Color.Yellow.copy(alpha = 0.5f))
+    val selectedColor: StateFlow<Color> = _selectedColor.asStateFlow()
+
+    private val _annotations = MutableStateFlow<List<AnnotationStroke>>(emptyList())
+    val annotations: StateFlow<List<AnnotationStroke>> = _annotations.asStateFlow()
+
+    // Document management
+    private var document: PDDocument? = null
+    private var pdfRenderer: PDFRenderer? = null
+    private val documentMutex = Mutex()
+
+    // Bitmap Cache
+    // Calculate cache size: Use 1/8th of the available memory for this memory cache.
+    private val maxMemory = (Runtime.getRuntime().maxMemory() / 1024).toInt()
+    private val cacheSize = maxMemory / 8
+
+    private val bitmapCache = object : LruCache<Int, Bitmap>(cacheSize) {
+        override fun sizeOf(key: Int, bitmap: Bitmap): Int {
+            // The cache size will be measured in kilobytes rather than number of items.
+            return bitmap.byteCount / 1024
+        }
+
+        override fun entryRemoved(evicted: Boolean, key: Int, oldValue: Bitmap, newValue: Bitmap?) {
+             // Recycle bitmap if evicted to free native memory?
+             // Android Bitmaps on newer versions (Honeycomb+) are managed by Dalvik/ART,
+             // but recycling can still help with large images.
+             // However, reusing them via an object pool would be better than recycling if we re-render.
+             // For simplicity and safety against reusing recycled bitmaps, we won't manually recycle here
+             // immediately unless we are sure it's not used.
+             // Relying on GC is safer for ViewModels.
+        }
+    }
+
+    fun loadPdf(context: Context, uri: Uri, password: String = "") {
+        viewModelScope.launch {
+            _uiState.value = PdfViewerUiState.Loading
+            try {
+                if (!PDFBoxResourceLoader.isReady()) {
+                    PDFBoxResourceLoader.init(context.applicationContext)
+                }
+
+                closeDocument() // Close existing if any
+
+                withContext(Dispatchers.IO) {
+                    val inputStream = context.contentResolver.openInputStream(uri)
+                        ?: throw Exception("Cannot open URI")
+
+                    val doc = if (password.isNotEmpty()) {
+                        PDDocument.load(inputStream, password)
+                    } else {
+                        PDDocument.load(inputStream)
+                    }
+                    // inputStream is closed by PDDocument.load usually, but check source.
+                    // PDDocument.load(InputStream) reads the stream.
+
+                    documentMutex.withLock {
+                        document = doc
+                        pdfRenderer = PDFRenderer(doc)
+                    }
+
+                    _uiState.value = PdfViewerUiState.Loaded(doc.numberOfPages)
+                }
+            } catch (e: Exception) {
+                Log.e("PdfViewerVM", "Error loading PDF", e)
+                _uiState.value = PdfViewerUiState.Error(e.message ?: "Failed to load PDF")
+            }
+        }
+    }
+
+    suspend fun loadPage(pageIndex: Int): Bitmap? {
+        // Check cache first
+        bitmapCache.get(pageIndex)?.let { return it }
+
+        return withContext(Dispatchers.IO) {
+            documentMutex.withLock {
+                try {
+                    val renderer = pdfRenderer ?: return@withLock null
+                    // Render at 1.5x scale (approx 108 dpi) for good quality on mobile
+                    val scale = 1.5f
+                    val bitmap = renderer.renderImage(pageIndex, scale)
+
+                    if (bitmap != null) {
+                        bitmapCache.put(pageIndex, bitmap)
+                    }
+                    bitmap
+                } catch (e: Exception) {
+                    Log.e("PdfViewerVM", "Error rendering page $pageIndex", e)
+                    null
+                }
+            }
+        }
+    }
+
+    fun setTool(tool: PdfTool) {
+        _toolState.value = tool
+        // Reset specific annotation tool if we leave Edit mode
+        if (tool != PdfTool.Edit) {
+            _selectedAnnotationTool.value = AnnotationTool.NONE
+        } else {
+            // Default to Highlighter when entering Edit mode
+            if (_selectedAnnotationTool.value == AnnotationTool.NONE) {
+                _selectedAnnotationTool.value = AnnotationTool.HIGHLIGHTER
+            }
+        }
+    }
+
+    fun setAnnotationTool(tool: AnnotationTool) {
+        _selectedAnnotationTool.value = tool
+        if (tool != AnnotationTool.NONE) {
+            _toolState.value = PdfTool.Edit
+        }
+    }
+
+    fun setColor(color: Color) {
+        _selectedColor.value = color
+    }
+
+    fun addAnnotation(stroke: AnnotationStroke) {
+        val currentList = _annotations.value.toMutableList()
+        currentList.add(stroke)
+        _annotations.value = currentList
+    }
+
+    fun undoAnnotation() {
+        val currentList = _annotations.value.toMutableList()
+        if (currentList.isNotEmpty()) {
+            currentList.removeAt(currentList.lastIndex)
+            _annotations.value = currentList
+        }
+    }
+
+    fun clearAnnotations() {
+        _annotations.value = emptyList()
+    }
+
+    private suspend fun closeDocument() {
+        documentMutex.withLock {
+            try {
+                document?.close()
+            } catch (e: Exception) {
+                Log.e("PdfViewerVM", "Error closing document", e)
+            } finally {
+                document = null
+                pdfRenderer = null
+                bitmapCache.evictAll()
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelScope.launch(Dispatchers.IO) {
+            closeDocument()
+        }
+    }
+}


### PR DESCRIPTION
- **Discovery**: `PdfViewerScreen` was managing state locally with booleans (`isSearchMode`, `isEditMode`) leading to potential cross-firing. It also loaded ALL PDF pages into memory as Bitmaps, causing OOM on large files.
- **Resolution**: Created `PdfViewerViewModel` with `PdfTool` sealed class for state management. Implemented `LruCache` for lazy-loading page bitmaps. Moved heavy PDF operations to `Dispatchers.IO` and used `produceState` for async rendering.
- **Performance Impact**: Reduced memory footprint significantly (O(1) vs O(N) pages). UI thread is no longer blocked by rendering.
- **Stability Note**: `PDDocument` is now properly managed and closed in ViewModel `onCleared`. Thread safety ensured with `Mutex`.

---
*PR created automatically by Jules for task [11000396859553555581](https://jules.google.com/task/11000396859553555581) started by @Karna14314*