### PR TITLE
⚡ Optimize getImageDimensions to prevent main thread blocking

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/util/ImageProcessor.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/ImageProcessor.kt
@@ -385,8 +385,8 @@ object ImageProcessor {
     /**
      * Get image dimensions without loading full bitmap.
      */
-    fun getImageDimensions(context: Context, uri: Uri): Pair<Int, Int>? {
-        return try {
+    suspend fun getImageDimensions(context: Context, uri: Uri): Pair<Int, Int>? = withContext(Dispatchers.IO) {
+        try {
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 val options = BitmapFactory.Options().apply {
                     inJustDecodeBounds = true

--- a/app/src/test/java/com/yourname/pdftoolkit/util/ImageProcessorTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/util/ImageProcessorTest.kt
@@ -1,0 +1,37 @@
+package com.yourname.pdftoolkit.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+class ImageProcessorTest {
+
+    @Test
+    fun test_getImageDimensions() = runBlocking {
+        val context: Context = RuntimeEnvironment.getApplication()
+        val width = 100
+        val height = 200
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+        val file = File(context.cacheDir, "test_image.png")
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+
+        val uri = Uri.fromFile(file)
+
+        val dimensions = ImageProcessor.getImageDimensions(context, uri)
+
+        assertEquals(width, dimensions?.first)
+        assertEquals(height, dimensions?.second)
+    }
+}


### PR DESCRIPTION
💡 **What:**
- Refactored `ImageProcessor.getImageDimensions` to be a `suspend` function.
- Wrapped the I/O logic in `withContext(Dispatchers.IO)`.
- Added `ImageProcessorTest.kt` to verify the function returns correct dimensions for a sample image.

🎯 **Why:**
- The previous implementation performed file I/O (stream decoding) on the calling thread, which could be the main thread, risking UI jank or ANRs.
- Offloading to `Dispatchers.IO` ensures safe execution regardless of the caller.

📊 **Measured Improvement:**
- **Baseline:** Established correctness using `ImageProcessorTest` (verified synchronous behavior).
- **Optimization:** Verified that the new `suspend` implementation passes the same correctness test.
- **Performance:** While raw execution time is similar (plus slight context switch overhead), this change eliminates the risk of blocking the UI thread, which is a critical performance metric for Android responsiveness. The change prevents potential ANRs when reading large images or from slow storage.

---
*PR created automatically by Jules for task [5188882504234387591](https://jules.google.com/task/5188882504234387591) started by @Karna14314*