### PR TITLE
Bolt: Fix PdfViewer save logic, optimize search, and improve Edit UX

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
@@ -669,6 +669,14 @@ private fun AnnotationToolbar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             ToolButton(
+                icon = Icons.Default.PanTool,
+                label = "Pan",
+                isSelected = selectedTool == AnnotationTool.NONE,
+                onClick = {
+                    onToolSelected(AnnotationTool.NONE)
+                }
+            )
+            ToolButton(
                 icon = Icons.Default.Highlight,
                 label = "Highlight",
                 isSelected = selectedTool == AnnotationTool.HIGHLIGHTER,

--- a/app/src/test/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModelTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModelTest.kt
@@ -45,14 +45,14 @@ class PdfViewerViewModelTest {
     }
 
     @Test
-    fun `setTool Edit sets default annotation tool`() {
+    fun `setTool Edit does not set default annotation tool`() {
         // Initial state
         assertEquals(AnnotationTool.NONE, viewModel.selectedAnnotationTool.value)
 
         viewModel.setTool(PdfTool.Edit)
 
-        // Should default to HIGHLIGHTER
-        assertEquals(AnnotationTool.HIGHLIGHTER, viewModel.selectedAnnotationTool.value)
+        // Should NOT default to HIGHLIGHTER anymore (stays NONE)
+        assertEquals(AnnotationTool.NONE, viewModel.selectedAnnotationTool.value)
         assertTrue(viewModel.toolState.value is PdfTool.Edit)
     }
 


### PR DESCRIPTION
This PR addresses several critical issues identified in the "Bolt" protocol audit:
1.  **Ghost Bug / Logic Fix**: The `saveAnnotations` function was creating empty PDFs because `importPage` return value was ignored. It is now correctly added to the document.
2.  **Performance Boost**: `search` function was re-parsing the PDF text and positions on every query. It now caches `PageTextData` (text + positions), significantly speeding up subsequent searches.
3.  **Data Leak**: `extractedTextCache` was not cleared when closing a document, potentially leaking data or showing wrong search results for new documents. It is now cleared in `closeDocument`.
4.  **UX Improvement**: Entering "Edit" mode no longer locks scrolling immediately. A "Pan" button (Hand tool) has been added to the toolbar to allow explicit scrolling while in Edit mode.
5.  **Tests**: Updated unit tests to verify the new state behavior.

---
*PR created automatically by Jules for task [4552016617382479637](https://jules.google.com/task/4552016617382479637) started by @Karna14314*