### PR TITLE
feat: High-quality vector annotation saving

### DIFF
--- a/distribution/whatsnew/whatsnew-en-US
+++ b/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,6 @@
-v1.3.5 - fix: 16KB alignment (upgrade AGP 8.7.3, CameraX 1.4.1, MLKit 16.0.1), debug symbols upload, file-based versioning (fixes gh variable 403 error)
+v1.3.6 - feat: High-quality vector annotations
 
+• Improved PDF Saving: Annotations are now saved as high-quality vector paths, preserving original text and significantly reducing file size.
 • Latest improvements and bug fixes
 • Android 15 (16 KB page alignment) compatible
 • Enhanced performance and stability


### PR DESCRIPTION
This PR enhances the PDF saving functionality in `PdfViewerViewModel` by implementing vector-based annotations. Previously, saving annotations would rasterize the entire page into an image, causing loss of text selectability and increased file size. The new implementation injects vector paths directly into the PDF content stream using `PDPageContentStream` with `AppendMode.APPEND`, preserving the underlying content. It also introduces a `RENDER_SCALE` constant for consistency and optimizes graphics state management. A safe fallback to rasterization is maintained for rotated pages to avoid coordinate system complexity.

---
*PR created automatically by Jules for task [18359986834895770161](https://jules.google.com/task/18359986834895770161) started by @Karna14314*