### PR TITLE
Refactor file size calculation logic to fix 0 MB bug

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/FilesScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/FilesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.yourname.pdftoolkit.data.FileManager
 import com.yourname.pdftoolkit.data.PersistedFile
 import com.yourname.pdftoolkit.data.SafUriManager
 import kotlinx.coroutines.launch
@@ -384,7 +385,7 @@ private fun RecentFileItem(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
-                        text = formatFileSize(file.size),
+                        text = FileManager.formatFileSize(file.size),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -433,14 +434,6 @@ private fun getFileIcon(mimeType: String): ImageVector {
         mimeType.contains("excel") || mimeType.contains("spreadsheet") -> Icons.Default.TableView
         mimeType.contains("powerpoint") || mimeType.contains("presentation") -> Icons.Default.Slideshow
         else -> Icons.Default.InsertDriveFile
-    }
-}
-
-private fun formatFileSize(bytes: Long): String {
-    return when {
-        bytes < 1024 -> "$bytes B"
-        bytes < 1024 * 1024 -> "${bytes / 1024} KB"
-        else -> "${bytes / (1024 * 1024)} MB"
     }
 }
 

--- a/app/src/main/java/com/yourname/pdftoolkit/util/OutputFolderManager.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/OutputFolderManager.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import androidx.core.content.FileProvider
+import com.yourname.pdftoolkit.data.FileManager
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -175,7 +176,7 @@ object OutputFolderManager {
                         uri = uri,
                         name = file.name,
                         size = file.length(),
-                        formattedSize = formatFileSize(file.length()),
+                        formattedSize = FileManager.formatFileSize(file.length()),
                         lastModified = file.lastModified()
                     )
                 } ?: emptyList()
@@ -233,15 +234,6 @@ object OutputFolderManager {
         }
         
         return fileName
-    }
-    
-    private fun formatFileSize(bytes: Long): String {
-        return when {
-            bytes < 1024 -> "$bytes B"
-            bytes < 1024 * 1024 -> "${bytes / 1024} KB"
-            bytes < 1024 * 1024 * 1024 -> String.format("%.1f MB", bytes / (1024.0 * 1024.0))
-            else -> String.format("%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0))
-        }
     }
     
     /**

--- a/app/src/test/java/com/yourname/pdftoolkit/data/FileManagerTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/data/FileManagerTest.kt
@@ -1,0 +1,46 @@
+package com.yourname.pdftoolkit.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileManagerTest {
+
+    @Test
+    fun formatFileSize_isCorrect() {
+        assertEquals("0 B", FileManager.formatFileSize(0))
+        assertEquals("0 B", FileManager.formatFileSize(-100))
+
+        assertEquals("100 B", FileManager.formatFileSize(100))
+        assertEquals("1023 B", FileManager.formatFileSize(1023))
+
+        // 1024 bytes -> 1 KB
+        assertEquals("1 KB", FileManager.formatFileSize(1024))
+
+        // 1500 / 1024 = 1.4648... -> 1.46 KB
+        assertEquals("1.46 KB", FileManager.formatFileSize(1500))
+
+        // 100 KB
+        assertEquals("100 KB", FileManager.formatFileSize(102400))
+
+        // 500 KB
+        assertEquals("500 KB", FileManager.formatFileSize(512000))
+
+        // < 1 MB (1048575 bytes) -> 1023.999 KB -> 1024 KB
+        assertEquals("1024 KB", FileManager.formatFileSize(1048575))
+
+        // 1 MB -> 1.00 MB (MB/GB keeps 2 decimals)
+        assertEquals("1.00 MB", FileManager.formatFileSize(1048576))
+
+        // 1.5 MB -> 1.50 MB
+        assertEquals("1.50 MB", FileManager.formatFileSize(1572864))
+
+        // 20 MB -> 20.00 MB
+        assertEquals("20.00 MB", FileManager.formatFileSize(20971520))
+
+        // 25 MB -> 25.00 MB
+        assertEquals("25.00 MB", FileManager.formatFileSize(26214400))
+
+        // 1 GB -> 1.00 GB
+        assertEquals("1.00 GB", FileManager.formatFileSize(1073741824))
+    }
+}


### PR DESCRIPTION
Updated the file size calculation logic to address the "0 MB" bug and ensure consistent, precise formatting across the app (Merge, Files, etc.).

Key changes:
- `FileManager.formatFileSize`: rewritten to use `log10` and `pow` with 1024 base.
- Formatting rules:
    - Bytes: "100 B"
    - KB (< 1 MB): "850 KB", "1.5 KB" (stripped trailing zeros)
    - MB/GB (>= 1 MB): "25.00 MB", "1.00 GB" (fixed 2 decimal places)
- Removed duplicate/buggy implementations in `OutputFolderManager` and `FilesScreen`.
- Added unit tests covering edge cases.

---
*PR created automatically by Jules for task [11057071579581994688](https://jules.google.com/task/11057071579581994688) started by @Karna14314*