### PR TITLE
fix: remove duplicate bitmap recycle guards

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfAnnotator.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfAnnotator.kt
@@ -455,10 +455,6 @@ class PdfAnnotator {
         
         // Guard: check bitmap is valid before creating canvas
         if (bitmap.isRecycled) return null
-        
-        if (bitmap.isRecycled) return null
-        if (bitmap.isRecycled) return null
-        if (bitmap.isRecycled) return null
         val canvas = Canvas(bitmap)
         
         // Background
@@ -729,10 +725,6 @@ class PdfAnnotator {
         }
         
         // Guard: check bitmap is valid before creating canvas
-        if (bitmap.isRecycled) return null
-        
-        if (bitmap.isRecycled) return null
-        if (bitmap.isRecycled) return null
         if (bitmap.isRecycled) return null
         val canvas = Canvas(bitmap)
         

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSigner.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSigner.kt
@@ -370,10 +370,6 @@ class PdfSigner(private val context: Context) {
         
         // Guard: check bitmap is valid before creating canvas
         if (bitmap.isRecycled) return null
-        
-        if (bitmap.isRecycled) return null
-        if (bitmap.isRecycled) return null
-        if (bitmap.isRecycled) return null
         val canvas = Canvas(bitmap)
         
         // Transparent background

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -395,8 +395,6 @@ class PdfViewerViewModel : ViewModel() {
             
             val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             if (bitmap.isRecycled) return@withLock null
-            if (bitmap.isRecycled) return@withLock null
-            if (bitmap.isRecycled) return null
             val canvas = Canvas(bitmap)
             canvas.drawColor(android.graphics.Color.WHITE) // White background
             


### PR DESCRIPTION
### Motivation
- Remove accidental duplicated `bitmap.isRecycled` guards introduced in a prior change to eliminate lint noise and incorrect/unreachable early returns while preserving existing runtime behavior.

### Description
- Removed redundant `if (bitmap.isRecycled) return` lines and kept a single guard immediately before each `Canvas(bitmap)` allocation in `PdfAnnotator`, `PdfSigner`, and `PdfViewerViewModel` to ensure safe Canvas creation without altering core logic.
- Files modified: `app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfAnnotator.kt`, `app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSigner.kt`, and `app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt`.

### Testing
- Attempted to run `./gradlew lintDebug testDebugUnitTest assembleDebug`, but the Gradle wrapper download failed due to proxy returning `HTTP/1.1 403 Forbidden`, so the wrapper-based run could not complete.
- Attempted to run Gradle with a local JDK (`JAVA_HOME=.../java/21.0.2`) and `gradle lintDebug testDebugUnitTest assembleDebug`, but the build failed because the Android Gradle Plugin (`com.android.application:8.9.1`) could not be resolved from repositories in this environment, so unit/lint/assemble verification could not complete.
- Code cleanup was committed as `fix: remove duplicate bitmap recycle guards` after local verification of the file edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb46b664b88326a6089b789f89393e)