### PR TITLE
Fix constraint overflow crash during zoom in PDF Viewer

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfAnnotator.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfAnnotator.kt
@@ -454,8 +454,7 @@ class PdfAnnotator {
         }
         
         // Guard: check bitmap is valid before creating canvas
-        if (bitmap.isRecycled) return null
-        val canvas = Canvas(bitmap)
+        val canvas = if (!bitmap.isRecycled) Canvas(bitmap) else return null
         
         // Background
         val bgPaint = Paint().apply {
@@ -725,8 +724,7 @@ class PdfAnnotator {
         }
         
         // Guard: check bitmap is valid before creating canvas
-        if (bitmap.isRecycled) return null
-        val canvas = Canvas(bitmap)
+        val canvas = if (!bitmap.isRecycled) Canvas(bitmap) else return null
         
         canvas.drawColor(Color.TRANSPARENT)
         

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSigner.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSigner.kt
@@ -369,8 +369,7 @@ class PdfSigner(private val context: Context) {
         }
         
         // Guard: check bitmap is valid before creating canvas
-        if (bitmap.isRecycled) return null
-        val canvas = Canvas(bitmap)
+        val canvas = if (!bitmap.isRecycled) Canvas(bitmap) else return null
         
         // Transparent background
         canvas.drawColor(Color.TRANSPARENT)

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
@@ -1256,30 +1256,11 @@ private fun PdfPageWithAnnotations(
                 // PDF page image - validate before use to prevent race conditions
                 val bitmapSnapshot = bitmap
                 if (bitmapSnapshot != null && !bitmapSnapshot.isRecycled && bitmapSnapshot.width > 0 && bitmapSnapshot.height > 0) {
-                    // Calculate scaled dimensions to prevent clipping
-                    val scaledWidth = size.width * scale
-                    val scaledHeight = size.height * scale
-                    val needsOverflow = scale > 1f
-
-                    // Convert pixels to dp
-                    val scaledWidthDp = with(density) { scaledWidth.toDp() }
-                    val scaledHeightDp = with(density) { scaledHeight.toDp() }
-
                     Image(
                         bitmap = bitmapSnapshot.asImageBitmap(),
                         contentDescription = "Page ${pageIndex + 1}",
                         modifier = Modifier
-                            .then(
-                                if (needsOverflow) {
-                                    // When zoomed, use exact size to prevent clipping
-                                    Modifier.size(
-                                        width = scaledWidthDp,
-                                        height = scaledHeightDp
-                                    )
-                                } else {
-                                    Modifier.fillMaxWidth()
-                                }
-                            )
+                            .fillMaxWidth()
                             // Per-page zoom: apply scale and pan to each Image
                             .graphicsLayer {
                                 scaleX = scale
@@ -1287,7 +1268,7 @@ private fun PdfPageWithAnnotations(
                                 translationX = pagePanX
                                 transformOrigin = androidx.compose.ui.graphics.TransformOrigin.Center
                             },
-                        contentScale = if (needsOverflow) ContentScale.Fit else ContentScale.FillWidth
+                        contentScale = ContentScale.FillWidth
                     )
                 } else {
                     // Invalid bitmap - show placeholder

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -394,8 +394,7 @@ class PdfViewerViewModel : ViewModel() {
             val height = (page.height * scale).toInt()
             
             val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-            if (bitmap.isRecycled) return null
-            val canvas = Canvas(bitmap)
+            val canvas = if (!bitmap.isRecycled) Canvas(bitmap) else return null
             canvas.drawColor(android.graphics.Color.WHITE) // White background
             
             page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)


### PR DESCRIPTION
1. All lines removed (before code)
```kotlin
                    // Calculate scaled dimensions to prevent clipping
                    val scaledWidth = size.width * scale
                    val scaledHeight = size.height * scale
                    val needsOverflow = scale > 1f

                    // Convert pixels to dp
                    val scaledWidthDp = with(density) { scaledWidth.toDp() }
                    val scaledHeightDp = with(density) { scaledHeight.toDp() }
...
                            .then(
                                if (needsOverflow) {
                                    // When zoomed, use exact size to prevent clipping
                                    Modifier.size(
                                        width = scaledWidthDp,
                                        height = scaledHeightDp
                                    )
                                } else {
                                    Modifier.fillMaxWidth()
                                }
                            )
...
                        contentScale = if (needsOverflow) ContentScale.Fit else ContentScale.FillWidth
```

2. Final state of the PageItem modifier chain (after code)
```kotlin
                        modifier = Modifier
                            .fillMaxWidth()
                            // Per-page zoom: apply scale and pan to each Image
                            .graphicsLayer {
                                scaleX = scale
                                scaleY = scale
                                translationX = pagePanX
                                transformOrigin = androidx.compose.ui.graphics.TransformOrigin.Center
                            },
                        contentScale = ContentScale.FillWidth
```

3. Whether any other `scale * size` patterns were found and fixed
I grepped through `ui/screens/PdfViewerScreen.kt` for other occurrences of `size(` combined with `scale`. All other usages of `.size(` were using static dimension constants like `32.dp`, `24.dp`, etc., for UI elements (icons, progress indicators). The actual `scale` value was only constrained with `coerceIn(1f, 5f)` correctly elsewhere. So, only line 1260 was affected.

4. Build results for both flavors
Both `./gradlew :app:assemblePlaystoreDebug` and `./gradlew :app:assembleFdroidDebug` passed. I also successfully ran all unit tests for Playstore flavor (`./gradlew :app:testPlaystoreDebugUnitTest`).

---
*PR created automatically by Jules for task [12601885936064541749](https://jules.google.com/task/12601885936064541749) started by @Karna14314*