### PR TITLE
fix: stabilize PdfViewerScreen and ViewModel memory, gesture, and rendering issues

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
@@ -1145,7 +1146,7 @@ private fun PdfPagesContent(
         LazyColumn(
             state = listState,
             // ALWAYS enable vertical scrolling - LazyColumn handles all vertical scroll
-            userScrollEnabled = !isEditMode || selectedTool == AnnotationTool.NONE,
+            userScrollEnabled = (!isEditMode || selectedTool == AnnotationTool.NONE) && scale <= 1f,
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = PaddingValues(vertical = 8.dp)
@@ -1274,13 +1275,17 @@ private fun PdfPageWithAnnotations(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                        translationX = pagePanX
-                        clip = true
-                    }
+                    .clipToBounds()
             ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer {
+                            scaleX = scale
+                            scaleY = scale
+                            translationX = pagePanX
+                        }
+                ) {
             if (!shouldLoad) {
                 Box(
                     modifier = Modifier
@@ -1478,6 +1483,7 @@ private fun PdfPageWithAnnotations(
                         )
                     }
                 }
+            }
             }
         }
         }

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -133,6 +133,8 @@ class PdfViewerViewModel : ViewModel() {
     // Document management
     private var document: PDDocument? = null
     private var pdfRenderer: PDFRenderer? = null
+    private var nativePdfRenderer: PdfRenderer? = null
+    private var nativePdfRendererPfd: ParcelFileDescriptor? = null
     private val documentMutex = Mutex()
     private var tempFile: File? = null
 
@@ -170,6 +172,19 @@ class PdfViewerViewModel : ViewModel() {
                             fileToLoad = File(uri.path!!)
                         } else {
                             // For content URIs, copy to a temp file
+
+                            // Actively scan and delete orphaned temp files
+                            try {
+                                val cacheFiles = context.cacheDir.listFiles()
+                                cacheFiles?.forEach { file ->
+                                    if (file.name.startsWith("pdf_view_")) {
+                                        file.delete()
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                Log.e("PdfViewerVM", "Error cleaning up orphaned temp files", e)
+                            }
+
                             // Create a unique temp file in cache dir
                             val temp = File.createTempFile("pdf_view_", ".pdf", context.cacheDir)
 
@@ -216,6 +231,14 @@ class PdfViewerViewModel : ViewModel() {
                             document = doc
                             pdfRenderer = PDFRenderer(doc)
                             tempFile = createdTempFile // Transfer ownership to instance
+
+                            try {
+                                val pfd = ParcelFileDescriptor.open(fileToLoad, ParcelFileDescriptor.MODE_READ_ONLY)
+                                nativePdfRendererPfd = pfd
+                                nativePdfRenderer = PdfRenderer(pfd)
+                            } catch (e: Exception) {
+                                Log.e("PdfViewerVM", "Failed to initialize native PdfRenderer", e)
+                            }
                         }
 
                         // CRITICAL: Pre-render first page BEFORE setting state to Loaded
@@ -357,18 +380,22 @@ class PdfViewerViewModel : ViewModel() {
     private fun isBitmapCorrupt(bitmap: Bitmap): Boolean {
         if (bitmap.width <= 0 || bitmap.height <= 0) return true
         
-        // Sample pixels to check for uniformity
         val width = bitmap.width
         val height = bitmap.height
-        val sampleSize = 10 // Check every 10th pixel
+        val pixels = IntArray(width * height)
         
+        // Pull all pixels into memory at once to avoid constant JNI boundary crossing
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+
+        val sampleSize = 10
         var firstPixel: Int? = null
         var uniformCount = 0
         var totalSamples = 0
         
         for (y in 0 until height step sampleSize) {
             for (x in 0 until width step sampleSize) {
-                val pixel = bitmap.getPixel(x, y)
+                val index = y * width + x
+                val pixel = pixels[index]
                 if (firstPixel == null) {
                     firstPixel = pixel
                 } else if (pixel == firstPixel) {
@@ -386,19 +413,15 @@ class PdfViewerViewModel : ViewModel() {
      * Renders a PDF page using Android's native PdfRenderer.
      */
     private fun renderWithNativePdfRenderer(pageIndex: Int, scale: Float, pdfFile: File?): Bitmap? {
-        if (pdfFile == null || !pdfFile.exists()) {
-            Log.e("PdfViewerVM", "Cannot use native renderer: PDF file not available")
+        val renderer = nativePdfRenderer
+        if (renderer == null) {
+            Log.e("PdfViewerVM", "Cannot use native renderer: not initialized")
             return null
         }
         
-        var pfd: ParcelFileDescriptor? = null
-        var renderer: PdfRenderer? = null
         var page: PdfRenderer.Page? = null
         
         return try {
-            pfd = ParcelFileDescriptor.open(pdfFile, ParcelFileDescriptor.MODE_READ_ONLY)
-            renderer = PdfRenderer(pfd)
-            
             if (pageIndex >= renderer.pageCount) {
                 Log.e("PdfViewerVM", "Page index $pageIndex out of bounds for native renderer")
                 return null
@@ -422,13 +445,8 @@ class PdfViewerViewModel : ViewModel() {
             null
         } finally {
             page?.close()
-            renderer?.close()
-            pfd?.close()
         }
     }
-
-    // Track bitmaps awaiting delayed recycle to prevent returning them during fast scroll
-    private val pendingRecycleBitmaps = java.util.HashSet<Bitmap>()
 
     /**
      * Validates a bitmap for safe drawing operations.
@@ -438,8 +456,6 @@ class PdfViewerViewModel : ViewModel() {
         if (bitmap == null) return false
         if (bitmap.isRecycled) return false
         if (bitmap.width <= 0 || bitmap.height <= 0) return false
-        // CRITICAL: Check if bitmap is pending recycle (Fix D - fast scroll issue)
-        if (pendingRecycleBitmaps.contains(bitmap)) return false
         return true
     }
 
@@ -470,19 +486,8 @@ class PdfViewerViewModel : ViewModel() {
 
         override fun entryRemoved(evicted: Boolean, key: Int, oldValue: Bitmap?, newValue: Bitmap?) {
             super.entryRemoved(evicted, key, oldValue, newValue)
-            // Fix D: Track bitmap as pending recycle before delayed recycle
-            // This prevents returning recycled bitmaps during fast scroll
-            oldValue?.let { bitmap ->
-                pendingRecycleBitmaps.add(bitmap)
-                viewModelScope.launch(Dispatchers.IO) {
-                    delay(500)
-                    // Remove from pending set before recycling
-                    pendingRecycleBitmaps.remove(bitmap)
-                    if (!bitmap.isRecycled) {
-                        bitmap.recycle()
-                    }
-                }
-            }
+            // Removed manual bitmap.recycle() and pendingRecycleBitmaps completely
+            // Let the GC handle it to prevent black boxes and scrambled pixels bugs
         }
     }
 
@@ -994,12 +999,20 @@ class PdfViewerViewModel : ViewModel() {
     private suspend fun closeDocument() {
         documentMutex.withLock {
             try {
+                nativePdfRenderer?.close()
+                nativePdfRendererPfd?.close()
+            } catch (e: Exception) {
+                Log.e("PdfViewerVM", "Error closing native renderer", e)
+            }
+            try {
                 document?.close()
             } catch (e: Exception) {
                 Log.e("PdfViewerVM", "Error closing document", e)
             } finally {
                 document = null
                 pdfRenderer = null
+                nativePdfRenderer = null
+                nativePdfRendererPfd = null
                 extractedTextCache.clear()
                 bitmapCache.evictAll()
 

--- a/fix_all.py
+++ b/fix_all.py
@@ -1,8 +1,0 @@
-import subprocess
-import os
-
-# Create fix scripts again because the ones created previously got wiped or didn't run correctly or whatever.
-# The branch e3bbad2 state:
-# - PdfViewerViewModel.kt was untouched
-# - PdfViewerScreen.kt was untouched
-# Wait, I didn't push. Let me check git status first to know my branch state.


### PR DESCRIPTION
This PR stabilizes the custom PDF Viewer implementation by addressing several critical bugs:
1. **Clipping on Zoom:** The `Modifier.graphicsLayer` applied to the PDF page container has been wrapped in a parent `Box` with `clipToBounds()`. This prevents the zoomed-in image from being sliced by its original unscaled layout bounds.
2. **Gesture Conflict (Pan vs. Scroll):** In `PdfViewerScreen.kt`, the `LazyColumn` now dynamically disables user scrolling when zoomed in (`userScrollEnabled = ... && scale <= 1f`), locking the vertical list scroll so users can smoothly pan around the page.
3. **I/O Bottleneck:** Extracted `PdfRenderer` and its `ParcelFileDescriptor` to class-level variables in `PdfViewerViewModel`. They are now safely initialized in `loadPdf()` and closed in `closeDocument()`, effectively resolving the severe instantiation lag during rapid scrolling.
4. **Thread Safety & Scrambled Bitmaps:** 
    * Rewrote `isBitmapCorrupt()` to use `bitmap.getPixels(...)` for bulk array processing, eliminating JNI boundary crossing bottlenecks.
    * Completely deleted the inherently thread-unsafe `pendingRecycleBitmaps` Set.
    * Removed manual `.recycle()` calls from the `LruCache`'s `entryRemoved()`, appropriately relying on the modern Android GC, which fixes the black-box and scrambled pixel race conditions.
5. **Stabilize File Loading:** Added an active scan inside `loadPdf()` to locate and delete orphaned temporary files starting with `"pdf_view_"` in the cache directory, preventing storage bloat on initialization.

Both `playstore` and `fdroid` builds passed compilation locally. Unrelated pre-existing flaky tests in `ReviewSystemTest` have been intentionally left alone to keep this PR tightly focused on the stabilization fixes.

---
*PR created automatically by Jules for task [12095950576669130345](https://jules.google.com/task/12095950576669130345) started by @Karna14314*