### PR TITLE
Fix PDF viewer URI permission, zoom/scroll interaction, highlighter alpha, and AndroidX fragment race

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/HomeScreen.kt
@@ -1,6 +1,8 @@
 package com.yourname.pdftoolkit.ui.screens
 
+import android.content.Intent
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.animateFloatAsState
@@ -19,7 +21,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.yourname.pdftoolkit.data.SafUriManager
 import com.yourname.pdftoolkit.ui.navigation.Screen
+import kotlinx.coroutines.launch
 
 /**
  * Category tabs for organizing PDF tools.
@@ -47,6 +51,7 @@ fun HomeScreen(
     onOpenPdfViewer: (Uri, String) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var selectedCategory by remember { mutableStateOf(ToolCategory.ORGANIZE) }
     
     // PDF file picker
@@ -54,18 +59,30 @@ fun HomeScreen(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         // uri is null when user cancels - just do nothing
-        uri?.let {
-            val cursor = context.contentResolver.query(it, null, null, null, null)
-            var name = "PDF Document"
-            cursor?.use { c ->
-                if (c.moveToFirst()) {
-                    val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                    if (nameIndex >= 0) {
-                        name = c.getString(nameIndex)?.substringBeforeLast('.') ?: name
+        uri?.let { selectedUri ->
+            scope.launch {
+                // Persist SAF permission immediately so reopening from recent files won't fail.
+                val persistedFile = SafUriManager.addRecentFile(
+                    context,
+                    selectedUri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+
+                val name = persistedFile?.name?.substringBeforeLast('.') ?: run {
+                    var displayName = "PDF Document"
+                    context.contentResolver.query(selectedUri, null, null, null, null)?.use { c ->
+                        if (c.moveToFirst()) {
+                            val nameIndex = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            if (nameIndex >= 0) {
+                                displayName = c.getString(nameIndex)?.substringBeforeLast('.') ?: displayName
+                            }
+                        }
                     }
+                    displayName
                 }
+
+                onOpenPdfViewer(selectedUri, name)
             }
-            onOpenPdfViewer(it, name)
         }
     }
     

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
@@ -1145,8 +1145,9 @@ private fun PdfPagesContent(
     ) {
         LazyColumn(
             state = listState,
-            // ALWAYS enable vertical scrolling - LazyColumn handles all vertical scroll
-            userScrollEnabled = (!isEditMode || selectedTool == AnnotationTool.NONE) && scale <= 1f,
+            // Keep vertical scrolling enabled even when zoomed so users can pan through
+            // enlarged content naturally. Only disable while actively drawing annotations.
+            userScrollEnabled = !isEditMode || selectedTool == AnnotationTool.NONE,
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = PaddingValues(vertical = 8.dp)
@@ -1436,7 +1437,7 @@ private fun PdfPageWithAnnotations(
                             // Marker and other tools render opaque
                             val blendMode = if (stroke.tool == AnnotationTool.HIGHLIGHTER) BlendMode.Multiply else BlendMode.SrcOver
                             val drawColor = if (stroke.tool == AnnotationTool.HIGHLIGHTER) {
-                                stroke.color.copy(alpha = 0.35f)
+                                stroke.color.copy(alpha = 0.3f)
                             } else {
                                 stroke.color
                             }
@@ -1468,7 +1469,7 @@ private fun PdfPageWithAnnotations(
                         }
                         val liveBlendMode = if (selectedTool == AnnotationTool.HIGHLIGHTER) BlendMode.Multiply else BlendMode.SrcOver
                         val liveColor = if (selectedTool == AnnotationTool.HIGHLIGHTER) {
-                            selectedColor.copy(alpha = 0.35f)
+                            selectedColor.copy(alpha = 0.3f)
                         } else {
                             selectedColor
                         }
@@ -1617,4 +1618,3 @@ private fun openWithExternalApp(context: Context, pdfUri: Uri) {
         Toast.makeText(context, "No app found to open PDF", Toast.LENGTH_SHORT).show()
     }
 }
-

--- a/app/src/playstore/java/com/yourname/pdftoolkit/ui/pdfviewer/engine/AndroidXPdfViewerEngine.kt
+++ b/app/src/playstore/java/com/yourname/pdftoolkit/ui/pdfviewer/engine/AndroidXPdfViewerEngine.kt
@@ -27,12 +27,13 @@ class AndroidXPdfViewerEngine(
     override fun load(uri: Uri) {
         try {
             val fragment = PdfViewerFragment()
+            // Set URI before attaching fragment to avoid blank-page race in androidx.pdf.
+            fragment.documentUri = uri
             pdfFragment = fragment
             safeCommit(
                 fragmentManager.beginTransaction()
                     .replace(containerId, fragment, fragmentTag)
             )
-            fragment.documentUri = uri
         } catch (e: OutOfMemoryError) {
             Log.e(TAG, "OOM loading PDF — triggering fallback")
             callbacks.onFallbackRequired()


### PR DESCRIPTION
### Motivation
- Ensure files opened with the in-app picker keep valid SAF access so the viewer doesn't later report "permission may have expired" for `content://` URIs. 
- Restore expected navigation when a page is zoomed so users can vertically pan/scroll through enlarged pages rather than getting stuck on the first visible area. 
- Make highlighter rendering follow the toolkit guidelines (transparent multiply blend) so text remains readable under highlights. 
- Eliminate a race where the AndroidX `PdfViewerFragment` could attach before its `documentUri` was set, causing blank/partial initial renders.

### Description
- Persist SAF permission immediately after picking a document in the Home screen by calling `SafUriManager.addRecentFile(...)` and then resolve a display name safely; changed `app/src/main/java/com/yourname/pdftoolkit/ui/screens/HomeScreen.kt`. 
- Re-enabled vertical scrolling while zoomed (only keep scrolling disabled during active annotation drawing) by adjusting `userScrollEnabled` in the pages `LazyColumn`; changed `app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt`. 
- Updated highlighter alpha from `0.35f` to `0.3f` and ensured use of `BlendMode.Multiply` for highlights and live-draw so highlights are semi-transparent and non-stacking; changed `app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt`. 
- Set `fragment.documentUri = uri` before committing the fragment transaction in the AndroidX engine to prevent blank-page races; changed `app/src/playstore/java/com/yourname/pdftoolkit/ui/pdfviewer/engine/AndroidXPdfViewerEngine.kt`.

### Testing
- Attempted a quick compile check with `./gradlew :app:compileDebugKotlin`, which aborted in this environment due to Gradle/JDK incompatibility (`What went wrong: 25.0.1`), so no full CI build completed. 
- No unit/instrumentation tests were executed in this environment; changes are limited to viewer entry points, rendering/interaction, and engine lifecycle to minimize regression surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedec6fdf08326b55e7fa84a7a46f4)