### PR TITLE
[codex] Fix crash handling and PDF signing placement

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
@@ -424,12 +424,22 @@ class PdfCompressor {
                 
                 // Render page to bitmap at compression DPI
                 val bitmap = renderer.renderImageWithDPI(pageIndex, profile.dpi)
+                if (bitmap.isRecycled) {
+                    android.util.Log.w("PdfCompressor", "Skipping recycled rendered bitmap for page $pageIndex")
+                    continue
+                }
                 
                 // Create white-backed bitmap to handle transparent PDFs
                 val whiteBitmap = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
                 val canvas = android.graphics.Canvas(whiteBitmap)
                 canvas.drawColor(android.graphics.Color.WHITE)
-                canvas.drawBitmap(bitmap, 0f, 0f, null)
+                if (!bitmap.isRecycled) {
+                    canvas.drawBitmap(bitmap, 0f, 0f, null)
+                } else {
+                    android.util.Log.w("PdfCompressor", "Skipping draw for recycled bitmap on page $pageIndex")
+                    whiteBitmap.recycle()
+                    continue
+                }
                 
                 try {
                     // Create new page matching original dimensions
@@ -454,8 +464,12 @@ class PdfCompressor {
                         contentStream.drawImage(pdImage, 0f, 0f, pageRect.width, pageRect.height)
                     }
                 } finally {
-                    bitmap.recycle()
-                    whiteBitmap.recycle()
+                    if (!bitmap.isRecycled) {
+                        bitmap.recycle()
+                    }
+                    if (!whiteBitmap.isRecycled) {
+                        whiteBitmap.recycle()
+                    }
                 }
                 
                 onProgress((pageIndex + 1).toFloat() / totalPages)

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfMerger.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfMerger.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
-import java.io.InputStream
 import java.io.OutputStream
 
 /**
@@ -40,32 +39,31 @@ class PdfMerger {
         }
         
         val merger = PDFMergerUtility()
-        val inputStreams = mutableListOf<InputStream>()
+        var destinationDocument: PDDocument? = null
         
         try {
             ensureActive()
+            destinationDocument = PDDocument()
+            val destination = destinationDocument
 
-            // Load all input documents
+            // Load and append one source at a time so source documents do not accumulate.
             inputUris.forEachIndexed { index, uri ->
                 ensureActive()
 
-                val inputStream = context.contentResolver.openInputStream(uri)
-                    ?: return@withContext Result.failure(
-                        IllegalStateException("Cannot open file: $uri")
-                    )
-                
-                inputStreams.add(inputStream)
-                merger.addSource(inputStream)
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    PDDocument.load(inputStream, MemoryUsageSetting.setupTempFileOnly()).use { sourceDocument ->
+                        merger.appendDocument(destination, sourceDocument)
+                    }
+                } ?: return@withContext Result.failure(
+                    IllegalStateException("Cannot open file: $uri")
+                )
                 
                 onProgress((index + 1).toFloat() / (inputUris.size + 1))
             }
             
             ensureActive()
 
-            // Perform merge
-            merger.destinationStream = outputStream
-            // Use temp file memory setting to prevent OOM during merge of large files
-            merger.mergeDocuments(MemoryUsageSetting.setupTempFileOnly())
+            destination.save(outputStream)
             
             onProgress(1.0f)
             Result.success(Unit)
@@ -75,13 +73,10 @@ class PdfMerger {
         } catch (e: Exception) {
             Result.failure(e)
         } finally {
-            // Clean up all loaded streams
-            inputStreams.forEach { stream ->
-                try {
-                    stream.close()
-                } catch (e: Exception) {
-                    // Ignore cleanup errors
-                }
+            try {
+                destinationDocument?.close()
+            } catch (e: Exception) {
+                // Ignore cleanup errors
             }
         }
     }

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfOrganizer.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfOrganizer.kt
@@ -2,9 +2,12 @@ package com.yourname.pdftoolkit.domain.operations
 
 import android.content.Context
 import android.net.Uri
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.io.OutputStream
 
 /**
@@ -338,14 +341,38 @@ class PdfOrganizer {
         context: Context,
         uri: Uri
     ): Int = withContext(Dispatchers.IO) {
+        var tempFile: File? = null
+        var pfd: ParcelFileDescriptor? = null
+        var renderer: PdfRenderer? = null
+
         try {
-            context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                PDDocument.load(inputStream).use { document ->
-                    document.numberOfPages
+            val temp = File.createTempFile("page_count_", ".pdf", context.cacheDir)
+            tempFile = temp
+
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                temp.outputStream().use { output ->
+                    input.copyTo(output)
                 }
-            } ?: 0
+            } ?: return@withContext 0
+
+            pfd = ParcelFileDescriptor.open(temp, ParcelFileDescriptor.MODE_READ_ONLY)
+            renderer = PdfRenderer(pfd)
+            renderer.pageCount
         } catch (e: Exception) {
             0
+        } finally {
+            try {
+                renderer?.close()
+            } catch (_: Exception) {
+            }
+            try {
+                pfd?.close()
+            } catch (_: Exception) {
+            }
+            try {
+                tempFile?.delete()
+            } catch (_: Exception) {
+            }
         }
     }
     

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfScanner.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfScanner.kt
@@ -321,7 +321,12 @@ class PdfScanner(private val context: Context) {
         }
 
         return try {
-            canvas.drawBitmap(bitmap!!, left, top, paint)
+            val drawableBitmap = bitmap ?: return false
+            if (drawableBitmap.isRecycled) {
+                Log.w(logTag, "Skipping drawBitmap for recycled bitmap")
+                return false
+            }
+            canvas.drawBitmap(drawableBitmap, left, top, paint)
             true
         } catch (e: Exception) {
             Log.e(logTag, "Failed to draw bitmap: ${e.message}", e)

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/navigation/AppNavigation.kt
@@ -33,14 +33,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.navArgument
 import com.yourname.pdftoolkit.BuildConfig
 import com.yourname.pdftoolkit.ui.components.HistorySidebar
 import com.yourname.pdftoolkit.ui.screens.PdfViewerScreen
 import com.yourname.pdftoolkit.ui.screens.*
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
@@ -69,6 +66,76 @@ private fun cleanPdfCache(context: android.content.Context) {
         totalSize -= file.length()
         file.delete()
         android.util.Log.d("AppNavigation", "Deleted old cache file: ${file.name}")
+    }
+}
+
+private fun safeNavigate(
+    navController: NavHostController,
+    route: String?,
+    navOptions: (androidx.navigation.NavOptionsBuilder.() -> Unit)? = null
+) {
+    if (route.isNullOrBlank()) {
+        android.util.Log.w("AppNavigation", "Navigation skipped: empty route")
+        return
+    }
+
+    try {
+        if (navOptions != null) {
+            navController.navigate(route, navOptions)
+        } else {
+            navController.navigate(route)
+        }
+    } catch (e: IllegalArgumentException) {
+        android.util.Log.e("AppNavigation", "Navigation failed for route: $route", e)
+    } catch (e: IllegalStateException) {
+        android.util.Log.e("AppNavigation", "Navigation state invalid for route: $route", e)
+    }
+}
+
+private fun navigateToPdfViewer(
+    navController: NavHostController,
+    uri: Uri?,
+    name: String?
+) {
+    val uriString = uri?.toString().orEmpty()
+    if (uriString.isBlank()) {
+        android.util.Log.w("AppNavigation", "PDF viewer navigation skipped: empty URI")
+        return
+    }
+
+    val encodedUri = Uri.encode(uriString)
+    val encodedName = Uri.encode(name?.takeIf { it.isNotBlank() } ?: "PDF Document")
+    if (encodedUri.isNullOrBlank() || encodedName.isNullOrBlank()) {
+        android.util.Log.w("AppNavigation", "PDF viewer navigation skipped: invalid encoded arguments")
+        return
+    }
+
+    safeNavigate(navController, Screen.PdfViewer.createRoute(encodedUri, encodedName))
+}
+
+private fun navigateToPdfTool(
+    navController: NavHostController,
+    tool: String,
+    toolUri: Uri?,
+    toolName: String?
+) {
+    val uriString = toolUri?.toString().orEmpty()
+    if (uriString.isBlank()) {
+        android.util.Log.w("AppNavigation", "Tool navigation skipped for $tool: empty URI")
+        return
+    }
+
+    val encodedUri = Uri.encode(uriString)
+    val encodedName = Uri.encode(toolName?.takeIf { it.isNotBlank() } ?: "PDF Document")
+    if (encodedUri.isNullOrBlank() || encodedName.isNullOrBlank()) {
+        android.util.Log.w("AppNavigation", "Tool navigation skipped for $tool: invalid encoded arguments")
+        return
+    }
+
+    when (tool) {
+        "compress" -> safeNavigate(navController, "compress?uri=$encodedUri&name=$encodedName")
+        "watermark" -> safeNavigate(navController, "watermark?uri=$encodedUri&name=$encodedName")
+        else -> {}
     }
 }
 
@@ -243,7 +310,7 @@ fun AppNavigation(
         if (initialPdfUri != null) {
             // Navigate to PDF viewer when URI changes
             // Use pdf_viewer_direct route which already has access to initialPdfUri/initialPdfName
-            navController.navigate("pdf_viewer_direct") {
+            safeNavigate(navController, "pdf_viewer_direct") {
                 // Pop up to Tools to avoid building up a large back stack
                 popUpTo(Screen.Tools.route) { inclusive = false }
             }
@@ -361,15 +428,13 @@ fun AppNavigation(
             composable(Screen.Tools.route) {
                 ToolsScreen(
                     onNavigateToScreen = { screen ->
-                        navController.navigate(screen.route)
+                        safeNavigate(navController, screen.route)
                     },
                     onNavigateToRoute = { route ->
-                        navController.navigate(route)
+                        safeNavigate(navController, route)
                     },
                     onOpenPdfViewer = { uri, name ->
-                        val encodedUri = Uri.encode(uri.toString())
-                        val encodedName = Uri.encode(name)
-                        navController.navigate(Screen.PdfViewer.createRoute(encodedUri, encodedName))
+                        navigateToPdfViewer(navController, uri, name)
                     }
                 )
             }
@@ -377,9 +442,7 @@ fun AppNavigation(
             composable(Screen.Files.route) {
                 FilesScreen(
                     onOpenPdfViewer = { uri, name ->
-                        val encodedUri = Uri.encode(uri.toString())
-                        val encodedName = Uri.encode(name)
-                        navController.navigate(Screen.PdfViewer.createRoute(encodedUri, encodedName))
+                        navigateToPdfViewer(navController, uri, name)
                     }
                 )
             }
@@ -395,11 +458,13 @@ fun AppNavigation(
                 arguments = listOf(
                     navArgument("uri") {
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = null
                     },
                     navArgument("name") {
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = "PDF Document"
                     }
                 )
             ) { backStackEntry ->
@@ -454,13 +519,7 @@ fun AppNavigation(
                     pdfName = Uri.decode(name),
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToTool = { tool, toolUri, toolName ->
-                        val encodedUri = toolUri?.let { Uri.encode(it.toString()) } ?: ""
-                        val encodedName = Uri.encode(toolName ?: "PDF Document")
-                        when (tool) {
-                            "compress" -> navController.navigate("compress?uri=$encodedUri&name=$encodedName")
-                            "watermark" -> navController.navigate("watermark?uri=$encodedUri&name=$encodedName")
-                            else -> {}
-                        }
+                        navigateToPdfTool(navController, tool, toolUri, toolName)
                     }
                 )
             }
@@ -507,7 +566,7 @@ fun AppNavigation(
 
                 if (initialPdfUri != null && normalizedUri == null) {
                     LaunchedEffect(initialPdfUri) {
-                        navController.navigate(Screen.Tools.route) {
+                        safeNavigate(navController, Screen.Tools.route) {
                             popUpTo("pdf_viewer_direct") { inclusive = true }
                         }
                     }
@@ -518,18 +577,12 @@ fun AppNavigation(
                     pdfUri = normalizedUri,
                     pdfName = initialPdfName ?: "PDF Document",
                     onNavigateBack = {
-                        navController.navigate(Screen.Tools.route) {
+                        safeNavigate(navController, Screen.Tools.route) {
                             popUpTo("pdf_viewer_direct") { inclusive = true }
                         }
                     },
                     onNavigateToTool = { tool, toolUri, toolName ->
-                        val encodedUri = toolUri?.let { Uri.encode(it.toString()) } ?: ""
-                        val encodedName = Uri.encode(toolName ?: "PDF Document")
-                        when (tool) {
-                            "compress" -> navController.navigate("compress?uri=$encodedUri&name=$encodedName")
-                            "watermark" -> navController.navigate("watermark?uri=$encodedUri&name=$encodedName")
-                            else -> {}
-                        }
+                        navigateToPdfTool(navController, tool, toolUri, toolName)
                     }
                 )
             }
@@ -549,11 +602,13 @@ fun AppNavigation(
                 arguments = listOf(
                     navArgument("uri") { 
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = null
                     },
                     navArgument("name") { 
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
@@ -625,11 +680,13 @@ fun AppNavigation(
                 arguments = listOf(
                     navArgument("uri") { 
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = null
                     },
                     navArgument("name") { 
                         type = NavType.StringType
-                        defaultValue = ""
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { backStackEntry ->
@@ -676,6 +733,7 @@ fun AppNavigation(
                 arguments = listOf(
                     navArgument("operation") {
                         type = NavType.StringType
+                        nullable = true
                         defaultValue = "resize"
                     }
                 )
@@ -696,8 +754,7 @@ fun AppNavigation(
         onOpenFile = { uri ->
             isHistorySidebarOpen = false
             // Navigate to PDF viewer with the file
-            val encodedUri = Uri.encode(uri.toString())
-            navController.navigate(Screen.PdfViewer.createRoute(encodedUri, "PDF Document"))
+            navigateToPdfViewer(navController, uri, "PDF Document")
         }
     )
     } // End Box
@@ -733,7 +790,7 @@ private fun BottomNavigationBar(
                         BottomNavTab.FILES -> Screen.Files.route
                     }
                     
-                    navController.navigate(targetRoute) {
+                    safeNavigate(navController, targetRoute) {
                         // Pop up to start destination to avoid building up a stack
                         popUpTo(navController.graph.findStartDestination().id) {
                             saveState = true

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -102,6 +102,7 @@ class PdfViewerViewModel : ViewModel() {
 
     companion object {
         const val RENDER_SCALE = 1.5f  // ~108 DPI for text-based PDFs
+        private const val MAX_RENDER_DIMENSION_PX = 2048
     }
 
     private val _uiState = MutableStateFlow<PdfViewerUiState>(PdfViewerUiState.Idle)
@@ -163,11 +164,19 @@ class PdfViewerViewModel : ViewModel() {
     }
     
     private fun registerActiveBitmap(pageIndex: Int, bitmap: Bitmap) {
+        if (bitmap.isRecycled) {
+            Log.w("PdfViewerVM", "Skipping active registration for recycled bitmap on page $pageIndex")
+            bitmapCache.remove(pageIndex)
+            return
+        }
+
         synchronized(activeBitmaps) {
             // Remove old bitmap from active set if exists
             uiBitmapRefs[pageIndex]?.let { oldBitmap ->
-                activeBitmaps.remove(oldBitmap)
-                safeRecycle(oldBitmap)
+                if (oldBitmap !== bitmap) {
+                    activeBitmaps.remove(oldBitmap)
+                    safeRecycle(oldBitmap)
+                }
             }
             // Register new bitmap
             activeBitmaps.add(bitmap)
@@ -345,13 +354,27 @@ class PdfViewerViewModel : ViewModel() {
         }
         
         override fun entryRemoved(evicted: Boolean, key: Int, oldValue: Bitmap, newValue: Bitmap?) {
-            if (evicted) {
+            if (oldValue !== newValue && !activeBitmaps.contains(oldValue)) {
                 safeRecycle(oldValue)
             }
         }
     }
     
     private var loadJob: Job? = null
+
+    private fun calculateCappedRenderScale(pageIndex: Int): Float {
+        val page = document?.getPage(pageIndex) ?: return RENDER_SCALE
+        val box = page.cropBox ?: page.mediaBox ?: return RENDER_SCALE
+        val targetWidth = box.width * RENDER_SCALE
+        val targetHeight = box.height * RENDER_SCALE
+        val largestDimension = maxOf(targetWidth, targetHeight)
+
+        return if (largestDimension > MAX_RENDER_DIMENSION_PX) {
+            RENDER_SCALE * (MAX_RENDER_DIMENSION_PX / largestDimension)
+        } else {
+            RENDER_SCALE
+        }
+    }
     
     suspend fun loadPage(pageIndex: Int): Bitmap? {
         val totalPages = (_uiState.value as? PdfViewerUiState.Loaded)?.totalPages ?: return null
@@ -361,7 +384,7 @@ class PdfViewerViewModel : ViewModel() {
         bitmapCache.get(pageIndex)?.let { cached ->
             if (!cached.isRecycled) {
                 registerActiveBitmap(pageIndex, cached)
-                return cached
+                return if (!cached.isRecycled) cached else null
             }
             bitmapCache.remove(pageIndex)
         }
@@ -371,12 +394,20 @@ class PdfViewerViewModel : ViewModel() {
             val bitmap = withContext(Dispatchers.IO) {
                 documentMutex.withLock {
                     // Double-check cache inside lock
-                    bitmapCache.get(pageIndex)?.takeIf { !it.isRecycled }?.let { return@withLock it }
+                    bitmapCache.get(pageIndex)?.let { cached ->
+                        if (!cached.isRecycled) {
+                            return@withLock cached
+                        }
+                        bitmapCache.remove(pageIndex)
+                    }
 
                     val renderer = pdfRenderer ?: return@withLock null
                     try {
-                        renderer.renderImage(pageIndex, RENDER_SCALE)?.also { bm ->
-                            bitmapCache.put(pageIndex, bm)
+                        val renderScale = calculateCappedRenderScale(pageIndex)
+                        renderer.renderImage(pageIndex, renderScale)?.also { bm ->
+                            if (!bm.isRecycled) {
+                                bitmapCache.put(pageIndex, bm)
+                            }
                         }
                     } catch (e: Exception) {
                         Log.e("PdfViewerVM", "Render failed page $pageIndex: ${e.message}")
@@ -384,8 +415,14 @@ class PdfViewerViewModel : ViewModel() {
                     }
                 }
             }
-            if (bitmap != null) registerActiveBitmap(pageIndex, bitmap)
-            bitmap
+            if (bitmap == null || bitmap.isRecycled) {
+                if (bitmap?.isRecycled == true) {
+                    bitmapCache.remove(pageIndex)
+                }
+                return null
+            }
+            registerActiveBitmap(pageIndex, bitmap)
+            if (!bitmap.isRecycled) bitmap else null
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SignPdfScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SignPdfScreen.kt
@@ -1,17 +1,19 @@
 package com.yourname.pdftoolkit.ui.screens
 
+import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -23,11 +25,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -41,6 +47,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
 
 /**
  * ViewModel for Sign PDF Screen.
@@ -54,7 +63,6 @@ class SignPdfViewModel : ViewModel() {
     }
     
     fun addPathPoint(x: Float, y: Float) {
-        val currentPaths = _state.value.signaturePaths.toMutableList()
         val currentPath = _state.value.currentPath.toMutableList()
         currentPath.add(SignaturePoint(x, y))
         _state.value = _state.value.copy(currentPath = currentPath)
@@ -88,6 +96,15 @@ class SignPdfViewModel : ViewModel() {
     
     fun setSignatureSize(width: Float, height: Float) {
         _state.value = _state.value.copy(signatureWidth = width, signatureHeight = height)
+    }
+
+    fun setSignaturePlacement(x: Float, y: Float, width: Float, height: Float) {
+        _state.value = _state.value.copy(
+            signatureX = x,
+            signatureY = y,
+            signatureWidth = width,
+            signatureHeight = height
+        )
     }
     
     fun toggleAddDate() {
@@ -181,6 +198,111 @@ data class SignPdfUiState(
     val resultUri: Uri? = null
 )
 
+private data class SignaturePagePreview(
+    val bitmap: Bitmap,
+    val pageWidth: Float,
+    val pageHeight: Float
+)
+
+private data class SignaturePlacementRect(
+    val left: Float,
+    val top: Float,
+    val width: Float,
+    val height: Float
+)
+
+private suspend fun renderSignaturePagePreview(
+    context: android.content.Context,
+    uri: Uri,
+    pageIndex: Int
+): SignaturePagePreview? = withContext(Dispatchers.IO) {
+    var tempFile: File? = null
+    var pfd: ParcelFileDescriptor? = null
+    var renderer: PdfRenderer? = null
+    var page: PdfRenderer.Page? = null
+
+    try {
+        val temp = File.createTempFile("sign_preview_", ".pdf", context.cacheDir)
+        tempFile = temp
+
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(temp).use { output ->
+                input.copyTo(output)
+            }
+        } ?: return@withContext null
+
+        pfd = ParcelFileDescriptor.open(temp, ParcelFileDescriptor.MODE_READ_ONLY)
+        renderer = PdfRenderer(pfd)
+
+        if (renderer.pageCount == 0) return@withContext null
+
+        val safePageIndex = pageIndex.coerceIn(0, renderer.pageCount - 1)
+        page = renderer.openPage(safePageIndex)
+
+        val pageWidth = page.width.toFloat()
+        val pageHeight = page.height.toFloat()
+        val maxPreviewWidth = 1600
+        val scale = minOf(2f, maxPreviewWidth / pageWidth).coerceAtLeast(1f)
+        val bitmapWidth = (page.width * scale).toInt().coerceAtLeast(1)
+        val bitmapHeight = (page.height * scale).toInt().coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(Color.WHITE)
+
+        page.render(
+            bitmap,
+            null,
+            null,
+            PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY
+        )
+
+        SignaturePagePreview(
+            bitmap = bitmap,
+            pageWidth = pageWidth,
+            pageHeight = pageHeight
+        )
+    } catch (e: Exception) {
+        null
+    } finally {
+        try {
+            page?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            renderer?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            pfd?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            tempFile?.delete()
+        } catch (_: Exception) {
+        }
+    }
+}
+
+private fun pdfRectToImageRect(
+    x: Float,
+    y: Float,
+    width: Float,
+    height: Float,
+    pageWidth: Float,
+    pageHeight: Float,
+    imageSize: Size
+): SignaturePlacementRect {
+    if (pageWidth <= 0f || pageHeight <= 0f || imageSize.width <= 0f || imageSize.height <= 0f) {
+        return SignaturePlacementRect(0f, 0f, 0f, 0f)
+    }
+
+    val left = (x / pageWidth) * imageSize.width
+    val rectWidth = (width / pageWidth) * imageSize.width
+    val rectHeight = (height / pageHeight) * imageSize.height
+    val top = imageSize.height - (((y + height) / pageHeight) * imageSize.height)
+
+    return SignaturePlacementRect(left, top, rectWidth, rectHeight)
+}
+
 /**
  * Sign PDF Screen - Add handwritten signatures to PDF documents.
  */
@@ -193,6 +315,11 @@ fun SignPdfScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsState()
     val scope = rememberCoroutineScope()
+    var pagePreview by remember { mutableStateOf<SignaturePagePreview?>(null) }
+    var previewError by remember { mutableStateOf<String?>(null) }
+    var dragStart by remember { mutableStateOf<Offset?>(null) }
+    var dragEnd by remember { mutableStateOf<Offset?>(null) }
+    val latestPagePreview by rememberUpdatedState(pagePreview)
     
     val pdfPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
@@ -211,6 +338,32 @@ fun SignPdfScreen(
         contract = ActivityResultContracts.CreateDocument("application/pdf")
     ) { uri ->
         uri?.let { viewModel.signPdf(context, it) }
+    }
+
+    LaunchedEffect(state.sourceUri, state.pageIndex) {
+        pagePreview?.bitmap?.let { bitmap ->
+            if (!bitmap.isRecycled) bitmap.recycle()
+        }
+        pagePreview = null
+        previewError = null
+        dragStart = null
+        dragEnd = null
+
+        val sourceUri = state.sourceUri ?: return@LaunchedEffect
+        val preview = renderSignaturePagePreview(context, sourceUri, state.pageIndex)
+        if (preview != null) {
+            pagePreview = preview
+        } else {
+            previewError = "Unable to render page preview"
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            latestPagePreview?.bitmap?.let { bitmap ->
+                if (!bitmap.isRecycled) bitmap.recycle()
+            }
+        }
     }
     
     Scaffold(
@@ -428,55 +581,165 @@ fun SignPdfScreen(
                         singleLine = true,
                         leadingIcon = { Icon(Icons.Default.Description, contentDescription = null) }
                     )
-                    
-                    // Position
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        OutlinedTextField(
-                            value = state.signatureX.toInt().toString(),
-                            onValueChange = { value ->
-                                value.toFloatOrNull()?.let { viewModel.setSignaturePosition(it, state.signatureY) }
-                            },
-                            label = { Text("X Position") },
-                            modifier = Modifier.weight(1f),
-                            singleLine = true
-                        )
-                        OutlinedTextField(
-                            value = state.signatureY.toInt().toString(),
-                            onValueChange = { value ->
-                                value.toFloatOrNull()?.let { viewModel.setSignaturePosition(state.signatureX, it) }
-                            },
-                            label = { Text("Y Position") },
-                            modifier = Modifier.weight(1f),
-                            singleLine = true
-                        )
-                    }
-                    
-                    // Size
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        OutlinedTextField(
-                            value = state.signatureWidth.toInt().toString(),
-                            onValueChange = { value ->
-                                value.toFloatOrNull()?.let { viewModel.setSignatureSize(it, state.signatureHeight) }
-                            },
-                            label = { Text("Width") },
-                            modifier = Modifier.weight(1f),
-                            singleLine = true
-                        )
-                        OutlinedTextField(
-                            value = state.signatureHeight.toInt().toString(),
-                            onValueChange = { value ->
-                                value.toFloatOrNull()?.let { viewModel.setSignatureSize(state.signatureWidth, it) }
-                            },
-                            label = { Text("Height") },
-                            modifier = Modifier.weight(1f),
-                            singleLine = true
-                        )
+
+                    val preview = pagePreview
+                    when {
+                        state.sourceUri == null -> {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(220.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(MaterialTheme.colorScheme.surface),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "Select a PDF to place the signature",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        preview == null && previewError == null -> {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(220.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(MaterialTheme.colorScheme.surface),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                        previewError != null -> {
+                            Text(
+                                text = previewError.orEmpty(),
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                        preview != null -> {
+                            BoxWithConstraints(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(MaterialTheme.colorScheme.surface)
+                                    .border(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outline,
+                                        RoundedCornerShape(8.dp)
+                                    )
+                            ) {
+                                val aspectRatio = preview.bitmap.width.toFloat() / preview.bitmap.height.toFloat()
+
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(aspectRatio)
+                                ) {
+                                    Image(
+                                        bitmap = preview.bitmap.asImageBitmap(),
+                                        contentDescription = "Page ${state.pageIndex + 1}",
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentScale = ContentScale.FillBounds
+                                    )
+
+                                    Canvas(
+                                        modifier = Modifier
+                                            .matchParentSize()
+                                            .pointerInput(preview.pageWidth, preview.pageHeight) {
+                                                detectDragGestures(
+                                                    onDragStart = { offset ->
+                                                        dragStart = offset
+                                                        dragEnd = offset
+                                                    },
+                                                    onDrag = { change, _ ->
+                                                        change.consume()
+                                                        dragEnd = change.position
+                                                    },
+                                                    onDragEnd = {
+                                                        val start = dragStart
+                                                        val end = dragEnd
+                                                        if (start != null && end != null && size.width > 0 && size.height > 0) {
+                                                            val left = minOf(start.x, end.x).coerceIn(0f, size.width.toFloat())
+                                                            val right = maxOf(start.x, end.x).coerceIn(0f, size.width.toFloat())
+                                                            val top = minOf(start.y, end.y).coerceIn(0f, size.height.toFloat())
+                                                            val bottom = maxOf(start.y, end.y).coerceIn(0f, size.height.toFloat())
+                                                            val rectWidth = right - left
+                                                            val rectHeight = bottom - top
+
+                                                            if (rectWidth > 0f && rectHeight > 0f) {
+                                                                val pdfX = (left / size.width.toFloat()) * preview.pageWidth
+                                                                val pdfWidth = (rectWidth / size.width.toFloat()) * preview.pageWidth
+                                                                val pdfHeight = (rectHeight / size.height.toFloat()) * preview.pageHeight
+                                                                val pdfY = preview.pageHeight - ((bottom / size.height.toFloat()) * preview.pageHeight)
+
+                                                                viewModel.setSignaturePlacement(pdfX, pdfY, pdfWidth, pdfHeight)
+                                                            }
+                                                        }
+                                                        dragStart = null
+                                                        dragEnd = null
+                                                    }
+                                                )
+                                            }
+                                    ) {
+                                        val activeStart = dragStart
+                                        val activeEnd = dragEnd
+                                        val rect = if (activeStart != null && activeEnd != null) {
+                                            SignaturePlacementRect(
+                                                left = minOf(activeStart.x, activeEnd.x),
+                                                top = minOf(activeStart.y, activeEnd.y),
+                                                width = kotlin.math.abs(activeEnd.x - activeStart.x),
+                                                height = kotlin.math.abs(activeEnd.y - activeStart.y)
+                                            )
+                                        } else {
+                                            pdfRectToImageRect(
+                                                x = state.signatureX,
+                                                y = state.signatureY,
+                                                width = state.signatureWidth,
+                                                height = state.signatureHeight,
+                                                pageWidth = preview.pageWidth,
+                                                pageHeight = preview.pageHeight,
+                                                imageSize = size
+                                            )
+                                        }
+
+                                        if (rect.width > 0f && rect.height > 0f) {
+                                            drawRect(
+                                                color = androidx.compose.ui.graphics.Color(0xFF1E88E5).copy(alpha = 0.12f),
+                                                topLeft = Offset(rect.left, rect.top),
+                                                size = Size(rect.width, rect.height)
+                                            )
+                                            drawRect(
+                                                color = androidx.compose.ui.graphics.Color(0xFF1E88E5),
+                                                topLeft = Offset(rect.left, rect.top),
+                                                size = Size(rect.width, rect.height),
+                                                style = Stroke(
+                                                    width = 3f,
+                                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(16f, 10f), 0f)
+                                                )
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    Icons.Default.TouchApp,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Page ${state.pageIndex + 1} • tap and drag to reposition",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/yourname/pdftoolkit/util/FileOpener.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/FileOpener.kt
@@ -66,9 +66,10 @@ object FileOpener {
      * @param uri URI of the image file
      * @return true if intent was launched successfully
      */
-    suspend fun openImage(context: Context, uri: Uri): Boolean {
+    suspend fun openImage(context: Context, uri: Uri?): Boolean {
         return try {
-            val accessibleUri = getAccessibleUri(context, uri, "image")
+            val imageUri = requireOpenableImageUri(context, uri)
+            val accessibleUri = getAccessibleUri(context, imageUri, "image")
             
             val intent = Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(accessibleUri, "image/*")
@@ -77,9 +78,37 @@ object FileOpener {
             context.startActivity(intent)
             true
         } catch (e: Exception) {
+            android.util.Log.e("FileOpener", "Unable to open image: ${e.message}", e)
             Toast.makeText(context, "No image viewer available", Toast.LENGTH_SHORT).show()
             false
         }
+    }
+
+    private suspend fun requireOpenableImageUri(context: Context, uri: Uri?): Uri = withContext(Dispatchers.IO) {
+        val imageUri = uri ?: throw IllegalArgumentException("Image URI must not be null")
+
+        when (imageUri.scheme) {
+            "file" -> {
+                val path = imageUri.path
+                    ?: throw IllegalArgumentException("Image file URI has no resolved path: $imageUri")
+                if (path.isBlank()) {
+                    throw IllegalArgumentException("Image file URI has an empty resolved path: $imageUri")
+                }
+                if (!File(path).exists()) {
+                    throw IllegalArgumentException("Image file does not exist: $path")
+                }
+            }
+            "content" -> {
+                val inputStream = context.contentResolver.openInputStream(imageUri)
+                    ?: throw IllegalArgumentException("Unable to open input stream for image URI: $imageUri")
+                inputStream.use {
+                    // Opening the stream is enough to validate provider access.
+                }
+            }
+            null, "" -> throw IllegalArgumentException("Image URI has no scheme: $imageUri")
+        }
+
+        imageUri
     }
     
     /**
@@ -243,7 +272,10 @@ object FileOpener {
             
             val cachedFile = File(cacheDir, "open_${System.currentTimeMillis()}.$extension")
             
-            context.contentResolver.openInputStream(uri)?.use { input ->
+            val inputStream = context.contentResolver.openInputStream(uri)
+                ?: throw IllegalArgumentException("Unable to open input stream for URI: $uri")
+
+            inputStream.use { input ->
                 FileOutputStream(cachedFile).use { output ->
                     input.copyTo(output)
                 }


### PR DESCRIPTION
## What changed

- Hardened navigation calls and nullable route arguments to avoid navigation crashes from invalid or missing URI arguments.
- Fixed recycled bitmap drawing paths and guarded bitmap cache eviction against active UI references.
- Reduced OOM risk in merge, page counting, and PDF page rendering.
- Hardened image opening against null or unopenable URIs.
- Replaced manual Sign PDF placement fields with drag-to-place PDF page preview while keeping stamping logic unchanged.

## Why

These changes address the crash/OOM issues found during the release audit and improve the Sign PDF placement workflow before Play Store submission.

## Validation

- Ran `./gradlew.bat :app:assemblePlaystoreDebug` successfully.
- Installed and launched the Play Store debug APK on connected device `22041219PI`.
