### PR TITLE
fix: resolve blank pages after PDF compression

### DIFF
--- a/AI_RUN_LOG.md
+++ b/AI_RUN_LOG.md
@@ -65,3 +65,6 @@ Each entry represents one week's focused improvement to the PDF viewer and edito
 **Branch:** auto/weekly-20260516-document-close-scroll-fix
 **Notes:**
 - closeDocument requires documentMutex.withLock which contains heavy synchronous file deletion logic.
+Fixes Applied to PdfCompressor.kt
+- Removed SMask from optimized images to fix compatibility with mobile viewers (Acrobat, Drive) that drop DCTDecode images with SMasks.
+- Updated tryFullRerender to use pageRect.lowerLeftX and pageRect.lowerLeftY for drawImage coordinates, preventing images from rendering off-screen for PDFs with non-zero origins.

--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -180,3 +180,6 @@ The app should now:
 **Build Date**: May 7, 2026  
 **Base Stable Commit**: e892e7e (v1.3.169)  
 **Status**: ✅ Ready for Testing
+Fixes Applied to PdfCompressor.kt
+- Removed SMask from optimized images to fix compatibility with mobile viewers (Acrobat, Drive) that drop DCTDecode images with SMasks.
+- Updated tryFullRerender to use pageRect.lowerLeftX and pageRect.lowerLeftY for drawImage coordinates, preventing images from rendering off-screen for PDFs with non-zero origins.

--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
@@ -490,24 +490,20 @@ class PdfCompressor {
                     canvas.drawColor(android.graphics.Color.WHITE)
                     canvas.drawBitmap(scaledBitmap, 0f, 0f, null)
                     
-                    // Extract alpha channel
-                    val alphaBitmap = scaledBitmap.extractAlpha()
-                    
-                    var colorImage: PDImageXObject? = null
-                    var alphaImage: PDImageXObject? = null
-                    
                     try {
-                        colorImage = JPEGFactory.createFromImage(document, rgbBitmap, profile.jpegQuality)
-                        alphaImage = LosslessFactory.createFromImage(document, alphaBitmap)
+                        // Create white-backed RGB bitmap (flatten transparency)
+                        // This is necessary because many mobile PDF viewers (Drive, Acrobat)
+                        // fail to render DCTDecode (JPEG) images that have an SMask attached.
+                        val colorImage = JPEGFactory.createFromImage(document, rgbBitmap, profile.jpegQuality)
                         
-                        // Associate alpha mask as the SMask of the color image dictionary
-                        colorImage.cosObject.setItem(COSName.SMASK, alphaImage.cosObject)
+                        // Explicitly remove SMASK and MASK to ensure viewers don't expect them
+                        colorImage.cosObject.removeItem(COSName.SMASK)
+                        colorImage.cosObject.removeItem(COSName.MASK)
                         colorImage
                     } catch (e: Exception) {
                         null
                     } finally {
                         rgbBitmap.recycle()
-                        alphaBitmap.recycle()
                     }
                 } else {
                     JPEGFactory.createFromImage(document, scaledBitmap, profile.jpegQuality)
@@ -601,7 +597,7 @@ class PdfCompressor {
                         true,
                         true
                     ).use { contentStream ->
-                        contentStream.drawImage(pdImage, 0f, 0f, pageRect.width, pageRect.height)
+                        contentStream.drawImage(pdImage, pageRect.lowerLeftX, pageRect.lowerLeftY, pageRect.width, pageRect.height)
                     }
                 } finally {
                     if (!bitmap.isRecycled) {

--- a/distribution/whatsnew/whatsnew-en-US
+++ b/distribution/whatsnew/whatsnew-en-US
@@ -5,4 +5,4 @@ correctly across all pages. Fixed ANR/freeze when changing pages while zoomed.
 Double-tap zoom now focuses on the tapped area accurately.
 
 PDF Compressor: Fixed issue where compressing text-heavy PDFs would return the 
-original file unchanged. Compression now works correctly across all PDF types.
+original file unchanged. Compression now works correctly across all PDF types.- Fix PDF compression blank pages bug in third-party viewers.


### PR DESCRIPTION
## Description

This PR fixes a bug where compressed PDFs appeared as blank pages when viewed in third-party viewers such as Adobe Acrobat or Google Drive. 

**Root Causes & Fixes:**
1. **SMask Compatibility:** During `tryImageOptimization`, the compressor would extract alpha channels and set them as the `SMask` on `DCTDecode` (JPEG) images. Many mobile/basic PDF viewers fail to handle `SMask` on `DCTDecode` streams properly. 
    *   **Fix:** Removed the `SMask` attachment step completely. The image is now explicitly drawn on a white background, flattening the transparency, and saved purely as a JPEG. The `SMask` and `MASK` properties are explicitly removed.
2. **Coordinate Origins:** In `tryFullRerender`, the `PDPageContentStream` drew the rendered image at `0f, 0f`. For PDFs with non-zero origins in their MediaBox (e.g., cropped pages), this caused the image to be drawn entirely off-screen.
    *   **Fix:** Updated the drawing coordinates to explicitly use `pageRect.lowerLeftX` and `pageRect.lowerLeftY`.

## Testing Done
- Evaluated behavior using custom Robolectric test scripts creating `TestCompressionBug` cases locally. 
- Generated PDFs and manually verified their XObject composition and streams using PyMuPDF (`fitz`), `qpdf --check`, and `mutool`.
- Ran `testPlaystoreDebugUnitTest` and `testFdroidDebugUnitTest` to verify no regressions in operations. Both passed relevant tests.
- Note: Pre-existing failures in `ReviewSystemTest` were ignored as they are unrelated to PDF Compression.

Both `playstore` and `fdroid` builds compiled without any issues.

---
*PR created automatically by Jules for task [743939527838640100](https://jules.google.com/task/743939527838640100) started by @Karna14314*