### PR TITLE
[PERFORMANCE] Wrapped LazyColumn item data calculations in remember blocks

### DIFF
--- a/AI_RUN_LOG.md
+++ b/AI_RUN_LOG.md
@@ -1,0 +1,16 @@
+
+## $(date +%Y-%m-%d)
+**Status:** SUCCESS ✅
+**Category:** B — Performance
+**Task:** Wrapped LazyColumn item data calculations in remember blocks
+**Files Changed:**
+- app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt: Wrapped computationally expensive calculations inside `items` block (like `searchState.matches.filter` and `annotations.filter`) with `remember` to prevent excessive recompositions during scrolling.
+**Verification:**
+- Build: PASS
+- Tests: N/A
+- Emulator: SKIPPED
+**Performance Impact:**
+- Scroll performance: Expected significant reduction in main-thread allocations during scroll and zooming as list items no longer redundantly filter lists on every frame rendering pass.
+**Commit:** (see below)
+**Branch:** auto/weekly-$(date +%Y%m%d)-lazy-column-remember
+**Notes:** The main issue here was that the `.filter` calls for `searchState.matches` and `annotations` inside the LazyColumn loop meant that filtering happened on every recomposition step for every page in view. Wrapping with remember fixes it as suggested in memory constraints.

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt
@@ -1271,12 +1271,19 @@ private fun PdfPagesContent(
                     count = totalPages,
                     key = { it }
                 ) { index ->
-                    val pageMatches = searchState.matches.filter { it.pageIndex == index }
+                    val pageMatches = remember(searchState.matches, index) {
+                        searchState.matches.filter { it.pageIndex == index }
+                    }
                     val currentGlobalResult = searchState.matches.getOrNull(searchState.currentMatchIndex)
-                    val currentMatchIndexOnPage = if (currentGlobalResult != null && currentGlobalResult.pageIndex == index) {
-                        pageMatches.indexOf(currentGlobalResult)
-                    } else {
-                        -1
+                    val currentMatchIndexOnPage = remember(currentGlobalResult, pageMatches, index) {
+                        if (currentGlobalResult != null && currentGlobalResult.pageIndex == index) {
+                            pageMatches.indexOf(currentGlobalResult)
+                        } else {
+                            -1
+                        }
+                    }
+                    val pageAnnotations = remember(annotations, index) {
+                        annotations.filter { it.pageIndex == index }
                     }
 
                     PdfPageWithAnnotations(
@@ -1285,7 +1292,7 @@ private fun PdfPagesContent(
                         isEditMode = isEditMode,
                         selectedTool = selectedTool,
                         selectedColor = selectedColor,
-                        annotations = annotations.filter { it.pageIndex == index },
+                        annotations = pageAnnotations,
                         currentStroke = if (currentDrawingPageIndex == index) currentStroke else emptyList(),
                         onCurrentStrokeChange = { stroke ->
                             onDrawingPageIndexChange(index)

--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,66 @@
+openjdk version "21.0.10" 2026-01-20
+OpenJDK Runtime Environment (build 21.0.10+7-Ubuntu-124.04)
+OpenJDK 64-Bit Server VM (build 21.0.10+7-Ubuntu-124.04, mixed mode, sharing)
+To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.11.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
+Daemon will be stopped at the end of the build
+
+> Configure project :app
+No keystore found or F-Droid build - skipping signing
+
+> Task :app:preBuild UP-TO-DATE
+> Task :app:preFdroidDebugBuild UP-TO-DATE
+> Task :app:mergeFdroidDebugNativeDebugMetadata NO-SOURCE
+> Task :app:generateFdroidDebugBuildConfig UP-TO-DATE
+> Task :app:checkFdroidDebugAarMetadata UP-TO-DATE
+> Task :app:generateFdroidDebugResValues UP-TO-DATE
+> Task :app:mapFdroidDebugSourceSetPaths UP-TO-DATE
+> Task :app:generateFdroidDebugResources UP-TO-DATE
+> Task :app:mergeFdroidDebugResources UP-TO-DATE
+> Task :app:packageFdroidDebugResources UP-TO-DATE
+> Task :app:parseFdroidDebugLocalResources UP-TO-DATE
+> Task :app:createFdroidDebugCompatibleScreenManifests UP-TO-DATE
+> Task :app:extractDeepLinksFdroidDebug UP-TO-DATE
+> Task :app:processFdroidDebugMainManifest UP-TO-DATE
+> Task :app:processFdroidDebugManifest UP-TO-DATE
+> Task :app:processFdroidDebugManifestForPackage UP-TO-DATE
+> Task :app:processFdroidDebugResources UP-TO-DATE
+> Task :app:javaPreCompileFdroidDebug UP-TO-DATE
+> Task :app:mergeFdroidDebugShaders UP-TO-DATE
+> Task :app:compileFdroidDebugShaders NO-SOURCE
+> Task :app:generateFdroidDebugAssets UP-TO-DATE
+> Task :app:mergeFdroidDebugAssets UP-TO-DATE
+> Task :app:compressFdroidDebugAssets UP-TO-DATE
+> Task :app:checkFdroidDebugDuplicateClasses UP-TO-DATE
+> Task :app:desugarFdroidDebugFileDependencies UP-TO-DATE
+> Task :app:mergeExtDexFdroidDebug UP-TO-DATE
+> Task :app:mergeLibDexFdroidDebug UP-TO-DATE
+> Task :app:mergeFdroidDebugJniLibFolders UP-TO-DATE
+> Task :app:mergeFdroidDebugNativeLibs UP-TO-DATE
+> Task :app:stripFdroidDebugDebugSymbols UP-TO-DATE
+> Task :app:validateSigningFdroidDebug UP-TO-DATE
+> Task :app:writeFdroidDebugAppMetadata UP-TO-DATE
+> Task :app:writeFdroidDebugSigningConfigVersions UP-TO-DATE
+> Task :app:kspFdroidDebugKotlin
+
+> Task :app:compileFdroidDebugKotlin
+w: file:///app/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerScreen.kt:2092:5 Parameter 'text' is never used
+
+> Task :app:compileFdroidDebugJavaWithJavac UP-TO-DATE
+> Task :app:dexBuilderFdroidDebug
+> Task :app:mergeFdroidDebugGlobalSynthetics UP-TO-DATE
+> Task :app:processFdroidDebugJavaRes UP-TO-DATE
+> Task :app:mergeFdroidDebugJavaResource UP-TO-DATE
+> Task :app:mergeProjectDexFdroidDebug
+> Task :app:packageFdroidDebug
+> Task :app:createFdroidDebugApkListingFileRedirect UP-TO-DATE
+> Task :app:assembleFdroidDebug
+[Incubating] Problems report is available at: file:///app/build/reports/problems/problems-report.html
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+For more on this, please refer to https://docs.gradle.org/8.11.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
+
+BUILD SUCCESSFUL in 52s
+38 actionable tasks: 5 executed, 33 up-to-date


### PR DESCRIPTION
This commit wraps computationally expensive calculations inside the `items` block of `LazyColumn` inside `PdfViewerScreen` (like `searchState.matches.filter` and `annotations.filter`) with `remember`. This prevents excessive recompositions during scrolling and zooming as list items no longer redundantly filter lists on every frame rendering pass. Also updated `AI_RUN_LOG.md`.

---
*PR created automatically by Jules for task [13671062511125796300](https://jules.google.com/task/13671062511125796300) started by @Karna14314*