### PR TITLE
feat: upgrade default encryption standard to AES-256

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSecurityManager.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfSecurityManager.kt
@@ -21,7 +21,7 @@ data class PdfSecurityOptions(
     val allowCopying: Boolean = false,
     val allowModifying: Boolean = false,
     val allowAnnotations: Boolean = false,
-    val keyLength: Int = 128 // 40 or 128 bits
+    val keyLength: Int = 256
 ) {
     // For backward compatibility, provide owner/user password accessors
     // Both use the same password for a simpler user experience


### PR DESCRIPTION
This PR changes the default keyLength from 128 to 256 in PdfSecurityOptions.

This single line change upgrades the application's underlying encryption engine from RC4 to the modern AES-256 standard. The current RC4-128 configuration leaves user files severely vulnerable. RC4 is a legacy stream cipher with known mathematical biases, allowing modern automated tools to reconstruct the encrypted data or trivially strip away document permissions (like disabling text copying or modifying) without even knowing the password. Furthermore, its lightweight nature allows modern hardware to brute-force user passwords exponentially faster than on an AES-256 vault.

Upgrading to a 256-bit key length forces pdfbox to drop the broken RC4 engine and fully protect user documents with industry-standard AES encryption.