### PR TITLE
fix(security): resolve lint errors in SecurityScreen

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SecurityScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SecurityScreen.kt
@@ -3,9 +3,6 @@ package com.yourname.pdftoolkit.ui.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
@@ -53,7 +50,7 @@ fun SecurityScreen(
     var allowCopying by remember { mutableStateOf(false) }
     var allowModifying by remember { mutableStateOf(false) }
     var isProcessing by remember { mutableStateOf(false) }
-    var progress by remember { mutableStateOf(0f) }
+    var progress by remember { mutableFloatStateOf(0f) }
     var showResult by remember { mutableStateOf(false) }
     var resultSuccess by remember { mutableStateOf(false) }
     var resultMessage by remember { mutableStateOf("") }


### PR DESCRIPTION
This PR addresses the issue with the PR for SecurityScreen that added KeyboardOptions(keyboardType = KeyboardType.Password) but caused CI to fail. 

**Root Cause of the CI Failure:**
The CI failure was not caused by the PR's addition of `KeyboardOptions(keyboardType = KeyboardType.Password)`. Instead, it was caused by two main issues found in `SecurityScreen.kt`:
1.  **Android Lint Warning (Fatal in CI):** The code was using `mutableStateOf(0f)` to manage float state, which triggers a Lint warning to "Prefer `mutableFloatStateOf` instead of `mutableStateOf`" to prevent autoboxing overhead.
2.  **Unused Imports:** Unused Compose animation imports (`AnimatedVisibility`, `fadeIn`, `fadeOut`) contributed to the code smell and lint output.

**Files Modified:**
- `app/src/main/java/com/yourname/pdftoolkit/ui/screens/SecurityScreen.kt`

**Commands Executed:**
1.  `./gradlew lintFdroidDebug`
2.  `./gradlew lintPlaystoreDebug`
3.  `./gradlew assembleDebug`
4.  `./gradlew testPlaystoreDebugUnitTest --tests "ReviewSystemTest"`

**Verification Results:**
- Lint checks (`lintFdroidDebug` and `lintPlaystoreDebug`) completed successfully without finding the `SecurityScreen` mutable state warning.
- The project builds correctly (`assembleDebug` succeeds).
- The failed tests (`ReviewSystemTest`) were identified as **pre-existing** failing tests in the repository and are not related to these changes.

**PR Status:**
The code changes fix the linting errors without removing the contributor's security improvement. The PR is now ready to merge.

---
*PR created automatically by Jules for task [8684036654201792055](https://jules.google.com/task/8684036654201792055) started by @Karna14314*