### PR TITLE
Fix delayed app language switching and UI updates

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/MainActivity.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/MainActivity.kt
@@ -64,8 +64,10 @@ class MainActivity : AppCompatActivity() {
     private var isLoadingState: androidx.compose.runtime.MutableState<Boolean>? = null
     
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Initialize language before Activity.onCreate so AppCompatDelegate applies locales immediately.
-        LanguageManager.initializeLanguage(this)
+        // Language is already applied by PdfToolkitApplication.onCreate() before any
+        // Activity is created — calling initializeLanguage() again here duplicated a
+        // blocking DataStore disk read on the main thread every cold start, adding to
+        // the perceived language-switch delay. Do not re-initialize here.
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         

--- a/app/src/main/java/com/yourname/pdftoolkit/util/LanguageDataStore.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/LanguageDataStore.kt
@@ -45,20 +45,4 @@ object LanguageDataStore {
         }
     }
     
-    /**
-     * Get the selected language synchronously (blocking).
-     * Use only for initialization where coroutines are not available.
-     *
-     * @param context Application context
-     * @return Language code or default
-     */
-    fun getSelectedLanguageSync(context: Context): String {
-        return try {
-            val prefs = context.dataStore.data
-            // This is a simplified sync read - in practice, use Flow
-            DEFAULT_LANGUAGE
-        } catch (e: Exception) {
-            DEFAULT_LANGUAGE
-        }
-    }
 }

--- a/app/src/main/java/com/yourname/pdftoolkit/util/LanguageManager.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/LanguageManager.kt
@@ -107,11 +107,30 @@ object LanguageManager {
         // Save to DataStore first to ensure persistence (await completion)
         LanguageDataStore.saveSelectedLanguage(context, langCode)
         
-        // Apply the locale change via AppCompatDelegate
-        // This will trigger activity recreation (since layoutDirection is not in configChanges)
+        // Apply the locale change via AppCompatDelegate.
+        // NOTE: On API 33+ this is proxied through the framework's LocaleManager via a
+        // binder IPC to system_server, which is asynchronous — the automatic activity
+        // recreation callback can lag noticeably (1-3s, worse on some OEM skins).
+        // Force an immediate recreate() rather than waiting on that callback so the UI
+        // updates in the same frame as the confirmation toast.
         setLanguage(context, langCode)
+        findActivity(context)?.recreate()
         
         Log.d("LanguageManager", "Language changed to: $langCode")
+    }
+
+    /**
+     * Unwrap a Context to find the underlying Activity, if any.
+     * Compose's LocalContext.current is usually the Activity directly, but this is
+     * defensive against future ContextWrapper layers (e.g. added theming providers).
+     */
+    private fun findActivity(context: Context): android.app.Activity? {
+        var ctx = context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is android.app.Activity) return ctx
+            ctx = ctx.baseContext
+        }
+        return ctx as? android.app.Activity
     }
 
     /**


### PR DESCRIPTION
Fixes the delayed app language switching by removing blocking IO during activity initialization and forcing immediate recreate.

---
*PR created automatically by Jules for task [3691774602614629608](https://jules.google.com/task/3691774602614629608) started by @Karna14314*