### PR TITLE
Fix language picker overflow in Settings

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/LanguageSelectionScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/LanguageSelectionScreen.kt
@@ -1,0 +1,161 @@
+package com.yourname.pdftoolkit.ui.screens
+
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.yourname.pdftoolkit.R
+import com.yourname.pdftoolkit.util.LanguageManager
+import kotlinx.coroutines.launch
+
+/**
+ * Dedicated full-screen language picker, used instead of a popup dialog now that the
+ * app supports 15 languages. A modal AlertDialog with a plain Column doesn't scroll or
+ * constrain its height, so past ~7-8 items the list overflowed the dialog bounds and
+ * items further down became unreachable/unclickable. A LazyColumn in a normal Scaffold
+ * scrolls correctly regardless of how many languages are added in the future, and a
+ * search field makes it fast to find one in a long list.
+ *
+ * @param currentLanguage The currently selected language code, used to show the checkmark.
+ * @param onNavigateBack Called when the user taps the back arrow.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LanguageSelectionScreen(
+    currentLanguage: String,
+    onNavigateBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var query by remember { mutableStateOf("") }
+
+    val filteredLanguages = remember(query) {
+        if (query.isBlank()) {
+            LanguageManager.supportedLanguages
+        } else {
+            LanguageManager.supportedLanguages.filter {
+                it.displayName.contains(query, ignoreCase = true)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.settings_select_language),
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.Default.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = { Text(stringResource(R.string.action_search)) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { query = "" }) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.action_clear))
+                        }
+                    }
+                },
+                singleLine = true,
+                shape = MaterialTheme.shapes.large
+            )
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 16.dp)
+            ) {
+                items(filteredLanguages, key = { it.code }) { language ->
+                    val isSelected = currentLanguage == language.code
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                scope.launch {
+                                    LanguageManager.changeLanguage(context, language.code)
+                                    Toast.makeText(
+                                        context,
+                                        R.string.settings_language_changed,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                    onNavigateBack()
+                                }
+                            }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = language.displayName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+                        )
+                        if (isSelected) {
+                            Icon(
+                                Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+
+                if (filteredLanguages.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = stringResource(R.string.settings_no_languages_found),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/SettingsScreen.kt
@@ -102,7 +102,7 @@ fun SettingsScreen(
     var showImageFormatDialog by remember { mutableStateOf(false) }
     var showLicensesDialog by remember { mutableStateOf(false) }
     var showThemeDialog by remember { mutableStateOf(false) }
-    var showLanguageDialog by remember { mutableStateOf(false) }
+    var showLanguageScreen by remember { mutableStateOf(false) }
     
     // Settings state
     var compressionQuality by remember { mutableStateOf(SettingsPreferences.getCompressionQuality(context)) }
@@ -121,6 +121,14 @@ fun SettingsScreen(
         }
     }
     
+    if (showLanguageScreen) {
+        LanguageSelectionScreen(
+            currentLanguage = currentLanguage,
+            onNavigateBack = { showLanguageScreen = false }
+        )
+        return
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -266,7 +274,7 @@ fun SettingsScreen(
                     title = stringResource(R.string.settings_select_language),
                     subtitle = LanguageManager.getLanguageDisplayName(currentLanguage),
                     icon = Icons.Default.Language,
-                    onClick = { showLanguageDialog = true }
+                    onClick = { showLanguageScreen = true }
                 )
             }
             
@@ -476,63 +484,6 @@ fun SettingsScreen(
             },
             confirmButton = {
                 TextButton(onClick = { showThemeDialog = false }) {
-                    Text(stringResource(R.string.action_cancel))
-                }
-            }
-        )
-    }
-    
-    // Language Selection Dialog
-    if (showLanguageDialog) {
-        AlertDialog(
-            onDismissRequest = { showLanguageDialog = false },
-            icon = { Icon(Icons.Default.Language, contentDescription = null) },
-            title = { Text(stringResource(R.string.settings_select_language)) },
-            text = {
-                Column {
-                    LanguageManager.supportedLanguages.forEach { language ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    scope.launch {
-                                        LanguageManager.changeLanguage(context, language.code)
-                                        showLanguageDialog = false
-                                        Toast.makeText(
-                                            context,
-                                            R.string.settings_language_changed,
-                                            Toast.LENGTH_SHORT
-                                        ).show()
-                                    }
-                                }
-                                .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            RadioButton(
-                                selected = currentLanguage == language.code,
-                                onClick = {
-                                    scope.launch {
-                                        LanguageManager.changeLanguage(context, language.code)
-                                        showLanguageDialog = false
-                                        Toast.makeText(
-                                            context,
-                                            R.string.settings_language_changed,
-                                            Toast.LENGTH_SHORT
-                                        ).show()
-                                    }
-                                }
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Text(
-                                text = language.displayName,
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-                        }
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { showLanguageDialog = false }) {
                     Text(stringResource(R.string.action_cancel))
                 }
             }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">نجاح</string>
     <string name="result_error">خطأ</string>
 
+    <string name="action_search">بحث</string>
+    <string name="settings_no_languages_found">لم يتم العثور على لغات</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -335,4 +335,6 @@
     <string name="result_success">Erfolg</string>
     <string name="result_error">Fehler</string>
 
-<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string></resources>
+<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string>    <string name="action_search">Suchen</string>
+    <string name="settings_no_languages_found">Keine Sprachen gefunden</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -339,4 +339,6 @@
     <string name="language_portuguese">Português (Brasil)</string>
 
     <string name="language_german">Alemán</string>
+    <string name="action_search">Buscar</string>
+    <string name="settings_no_languages_found">No se encontraron idiomas</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Succès</string>
     <string name="result_error">Erreur</string>
 
+    <string name="action_search">Rechercher</string>
+    <string name="settings_no_languages_found">Aucune langue trouvée</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -335,4 +335,6 @@
     <string name="result_success">सफल</string>
     <string name="result_error">त्रुटि</string>
 
-<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string></resources>
+<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string>    <string name="action_search">खोजें</string>
+    <string name="settings_no_languages_found">कोई भाषा नहीं मिली</string>
+</resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Kesuksesan</string>
     <string name="result_error">Kesalahan</string>
 
+    <string name="action_search">Cari</string>
+    <string name="settings_no_languages_found">Tidak ada bahasa yang ditemukan</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">成功</string>
     <string name="result_error">エラー</string>
 
+    <string name="action_search">検索</string>
+    <string name="settings_no_languages_found">言語が見つかりません</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">성공</string>
     <string name="result_error">오류</string>
 
+    <string name="action_search">검색</string>
+    <string name="settings_no_languages_found">언어를 찾을 수 없습니다</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -335,4 +335,6 @@
     <string name="result_success">Sucesso</string>
     <string name="result_error">Erro</string>
 
-<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string></resources>
+<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string>    <string name="action_search">Pesquisar</string>
+    <string name="settings_no_languages_found">Nenhum idioma encontrado</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Успех</string>
     <string name="result_error">Ошибка</string>
 
+    <string name="action_search">Поиск</string>
+    <string name="settings_no_languages_found">Языки не найдены</string>
 </resources>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Üstünlik</string>
     <string name="result_error">Roralňyşlyk</string>
 
+    <string name="action_search">Gözleg</string>
+    <string name="settings_no_languages_found">Dil tapylmady</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Başarı</string>
     <string name="result_error">Hata</string>
 
+    <string name="action_search">Ara</string>
+    <string name="settings_no_languages_found">Dil bulunamadı</string>
 </resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_success">Muvaffaqiyat</string>
     <string name="result_error">Xato</string>
 
+    <string name="action_search">Qidirish</string>
+    <string name="settings_no_languages_found">Tillar topilmadi</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -335,4 +335,6 @@
     <string name="result_success">成功</string>
     <string name="result_error">错误</string>
 
-<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string></resources>
+<string name="tool_image_compress">Compress Image</string><string name="tool_image_resize">Resize Image</string><string name="tool_image_convert">Convert Format</string><string name="tool_image_metadata">Strip Metadata</string>    <string name="action_search">搜索</string>
+    <string name="settings_no_languages_found">未找到语言</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,5 +339,7 @@
     <string name="result_success">Success</string>
     <string name="result_error">Error</string>
 
+    <string name="action_search">Search</string>
+    <string name="settings_no_languages_found">No languages found</string>
 </resources>
 


### PR DESCRIPTION
The Settings language picker dialog has been replaced with a full-screen `LanguageSelectionScreen`.

**Root Cause:**
The previous implementation used a Compose `AlertDialog` with a `Column` containing all 15 languages. Since `AlertDialog` doesn't automatically constraint the height of a plain `Column` or make it scrollable, the content overflowed the bounds of the dialog on most devices. This resulted in languages at the bottom of the list either being invisible or having incorrect/unresponsive touch targets.

**Fix Details:**
1. Created `LanguageSelectionScreen.kt` using a `Scaffold` and `LazyColumn`, ensuring smooth scrolling for any number of languages.
2. Added a search bar (`OutlinedTextField`) to allow filtering the languages.
3. Updated `SettingsScreen.kt` to conditionally show the new full-screen language selector instead of the old `AlertDialog`.
4. Added new string resources `action_search` and `settings_no_languages_found` across all 15 language `values` directories to maintain complete localization.

---
*PR created automatically by Jules for task [8777270618683382862](https://jules.google.com/task/8777270618683382862) started by @Karna14314*