### PR TITLE
Weekly Performance Optimization — Fix memory leak in PdfViewerViewModel.onCleared

### DIFF
--- a/AI_RUN_LOG.md
+++ b/AI_RUN_LOG.md
@@ -31,3 +31,19 @@
 **Commit:** auto/weekly-20260711-derived-state-scroll
 **Branch:** auto/weekly-20260711-derived-state-scroll
 **Notes:** Derived state should always be used when converting rapidly firing state (scroll events) into less frequently firing state (page index).
+
+## 2026-08-01
+**Status:** SUCCESS ✅
+**Category:** D — Memory Review
+**Task:** Fixed memory leak and potential crash in PdfViewerViewModel.onCleared by migrating coroutine to GlobalScope + NonCancellable
+**Files Changed:**
+- app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt: Changed viewModelScope.launch to GlobalScope.launch with NonCancellable to ensure cleanup completes even if ViewModel is destroyed.
+**Verification:**
+- Build: PASS
+- Tests: PASS
+- Emulator: SKIPPED
+**Performance Impact:**
+- Memory: Prevents memory leaks by ensuring large bitmaps and active open PDF documents are reliably cleaned up during garbage collection/app lifecycle transitions.
+**Commit:** auto/weekly-20260801-fix-oncleared-oom
+**Branch:** auto/weekly-20260801-fix-oncleared-oom
+**Notes:** Never launch critical I/O cleanup operations in a CoroutineScope that gets cancelled immediately.

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/PdfViewerViewModel.kt
@@ -1032,9 +1032,10 @@ fun eraseAnnotations(pageIndex: Int, eraserPoints: List<Offset>, eraserNormWidth
                 _uiState.update {
                     PdfViewerUiState.Error("Not enough memory. Close other apps and try again.")
                 }
-            } else throw e
+            } else Log.e("PdfViewerVM", "Error in onCleared cleanup", e)
         }
-        viewModelScope.launch(Dispatchers.IO + exceptionHandler) {
+        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO + kotlinx.coroutines.NonCancellable + exceptionHandler) {
             synchronized(activeBitmaps) {
                 uiBitmapRefs.values.forEach { if (!it.isRecycled) it.recycle() }
                 uiBitmapRefs.clear()


### PR DESCRIPTION
Fixed a memory leak and potential crash in PdfViewerViewModel.onCleared by migrating the cleanup coroutine from `viewModelScope` (which gets cancelled instantly) to `GlobalScope` with `NonCancellable`. This ensures large bitmaps and active open PDF documents are reliably cleaned up during garbage collection and app lifecycle transitions without throwing unhandled exceptions.

---
*PR created automatically by Jules for task [8600703630486703504](https://jules.google.com/task/8600703630486703504) started by @Karna14314*