### PR TITLE
Fix bottom toolbar overlap with system navigation bar on crop screens

### DIFF
--- a/app/src/main/AndroidManifest.xml.orig
+++ b/app/src/main/AndroidManifest.xml.orig
@@ -9,12 +9,12 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    
+
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29"
         tools:ignore="ScopedStorage" />
-    
+
     <!-- Camera permission for Scan to PDF feature -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
@@ -44,7 +44,7 @@
             android:theme="@style/Theme.PDFToolkit"
             android:enableOnBackInvokedCallback="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
-            
+
             <!-- Main Launcher Intent -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -58,7 +58,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-            
+
             <!-- PDF from content provider -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
@@ -67,7 +67,7 @@
                 <data android:scheme="content" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-            
+
             <!-- PDF from file -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -75,28 +75,28 @@
                 <data android:scheme="file" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-            
+
             <!-- Handle Send/Share Intent for PDF -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-            
+
             <!-- Handle multiple PDF share -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-            
+
             <!-- Handle images for conversion -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
-            
+
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -129,7 +129,7 @@
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.UCropActivity"/>
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
     </application>
 

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt.orig
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt.orig
@@ -1,0 +1,764 @@
+package com.yourname.pdftoolkit.ui.screens
+
+import android.app.Activity
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.border
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.AsyncImage
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.yourname.pdftoolkit.data.FileManager
+import com.yourname.pdftoolkit.data.HistoryManager
+import com.yourname.pdftoolkit.data.SafUriManager
+import com.yourname.pdftoolkit.data.OperationType
+import com.yourname.pdftoolkit.domain.operations.ImageConverter
+import com.yourname.pdftoolkit.domain.operations.PageSize
+import com.yourname.pdftoolkit.ui.components.*
+import com.yourname.pdftoolkit.util.CropHelper
+import com.yourname.pdftoolkit.util.FileOpener
+import com.yourname.pdftoolkit.util.OutputFolderManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Data class for selected image info.
+ */
+private data class ImageInfo(
+    val uri: Uri,
+    val name: String,
+    val originalIndex: Int = 0
+)
+
+/**
+ * Screen for converting images to PDF.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConvertScreen(
+    onNavigateBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val imageConverter = remember { ImageConverter() }
+
+    // State
+    var selectedImages by remember { mutableStateOf<List<ImageInfo>>(emptyList()) }
+    var pageSize by remember { mutableStateOf(PageSize.A4) }
+    var quality by remember { mutableStateOf(85f) }
+    var isProcessing by remember { mutableStateOf(false) }
+    var progress by remember { mutableStateOf(0f) }
+    var showResult by remember { mutableStateOf(false) }
+    var resultSuccess by remember { mutableStateOf(false) }
+    var resultMessage by remember { mutableStateOf("") }
+    var resultUri by remember { mutableStateOf<Uri?>(null) }
+    var useCustomLocation by remember { mutableStateOf(false) }
+
+    // Crop state - track which image index is being cropped
+    var cropImageIndex by remember { mutableStateOf(-1) }
+    var selectedItemIndex by remember { mutableStateOf<Int?>(null) }
+
+    val hasOrderChanged = remember(selectedImages) {
+        selectedImages.zipWithNext { a, b -> a.originalIndex > b.originalIndex }.any { it }
+    }
+
+    // Crop launcher - handles the result from uCrop activity
+    val cropLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val croppedUri = CropHelper.getResultUri(result.resultCode, result.data)
+            if (croppedUri != null && cropImageIndex >= 0 && cropImageIndex < selectedImages.size) {
+                // Replace the original image with the cropped one
+                val updatedImages = selectedImages.toMutableList()
+                val originalName = updatedImages[cropImageIndex].name
+                updatedImages[cropImageIndex] = ImageInfo(
+                    uri = croppedUri,
+                    name = "${originalName.substringBeforeLast(".")}_cropped.${originalName.substringAfterLast(".", "jpg")}"
+                )
+                selectedImages = updatedImages
+            }
+        }
+        cropImageIndex = -1
+    }
+
+    // Image picker launcher
+    val pickImagesLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        if (uris.isNotEmpty()) {
+            val currentSize = selectedImages.size
+            val newImages = uris.mapIndexedNotNull { index, uri ->
+                val info = FileManager.getFileInfo(context, uri)
+                if (info != null) {
+                    ImageInfo(
+                        uri = uri,
+                        name = info.name,
+                        originalIndex = currentSize + index
+                    )
+                } else null
+            }
+            selectedImages = selectedImages + newImages
+        }
+    }
+
+    // Save file launcher (for custom location)
+    val savePdfLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/pdf")
+    ) { uri ->
+        uri?.let { outputUri ->
+            if (selectedImages.isNotEmpty()) {
+                scope.launch {
+                    isProcessing = true
+                    progress = 0f
+
+                    val outputStream = context.contentResolver.openOutputStream(outputUri)
+                    if (outputStream != null) {
+                        val result = imageConverter.imagesToPdf(
+                            context = context,
+                            imageUris = selectedImages.map { it.uri },
+                            outputStream = outputStream,
+                            pageSize = pageSize,
+                            quality = quality.toInt(),
+                            onProgress = { progress = it }
+                        )
+
+                        outputStream.close()
+
+                        result.fold(
+                            onSuccess = { count ->
+                                resultSuccess = true
+                                resultUri = outputUri
+                                resultMessage = "Successfully converted $count images to PDF"
+                                selectedImages = emptyList()
+                            },
+                            onFailure = { error ->
+                                resultSuccess = false
+                                resultMessage = error.message ?: "Conversion failed"
+                            }
+                        )
+                    } else {
+                        resultSuccess = false
+                        resultMessage = "Cannot create output file"
+                    }
+
+                    isProcessing = false
+                    showResult = true
+                }
+            }
+        }
+    }
+
+    // Function to convert with default location
+    fun convertWithDefaultLocation() {
+        scope.launch {
+            isProcessing = true
+            progress = 0f
+            val imageCount = selectedImages.size
+
+            val result = withContext(Dispatchers.IO) {
+                try {
+                    val fileName = FileManager.generateOutputFileName("images")
+                    val outputResult = OutputFolderManager.createOutputStream(context, fileName)
+
+                    if (outputResult != null) {
+                        val convertResult = imageConverter.imagesToPdf(
+                            context = context,
+                            imageUris = selectedImages.map { it.uri },
+                            outputStream = outputResult.outputStream,
+                            pageSize = pageSize,
+                            quality = quality.toInt(),
+                            onProgress = { progress = it }
+                        )
+
+                        outputResult.outputStream.close()
+
+                        convertResult.fold(
+                            onSuccess = { count ->
+                                Triple(true, "Successfully converted $count images to PDF\n\nSaved to: ${OutputFolderManager.getOutputFolderPath(context)}/${outputResult.outputFile.fileName}", outputResult.outputFile.contentUri)
+                            },
+                            onFailure = { error ->
+                                outputResult.outputFile.file.delete()
+                                Triple(false, error.message ?: "Conversion failed", null)
+                            }
+                        )
+                    } else {
+                        Triple(false, "Cannot create output file", null)
+                    }
+                } catch (e: Exception) {
+                    Triple(false, e.message ?: "Conversion failed", null)
+                }
+            }
+
+            resultSuccess = result.first
+            resultMessage = result.second
+            resultUri = result.third
+
+            // Record in history
+            if (resultSuccess && result.third != null) {
+                // Add to recent files
+                SafUriManager.addRecentFile(context, result.third!!)
+
+                HistoryManager.recordSuccess(
+                    context = context,
+                    operationType = OperationType.CONVERT,
+                    inputFileName = "$imageCount images",
+                    outputFileUri = result.third,
+                    outputFileName = "images_to_pdf.pdf",
+                    details = "Converted $imageCount images to PDF"
+                )
+            } else if (!resultSuccess) {
+                HistoryManager.recordFailure(
+                    context = context,
+                    operationType = OperationType.CONVERT,
+                    inputFileName = "$imageCount images",
+                    errorMessage = result.second
+                )
+            }
+
+            if (resultSuccess) {
+                selectedImages = emptyList()
+            }
+            isProcessing = false
+            showResult = true
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            ToolTopBar(
+                title = "Convert Images",
+                onNavigateBack = onNavigateBack
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Content area
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                if (selectedImages.isEmpty()) {
+                    EmptyState(
+                        icon = Icons.Default.Image,
+                        title = "No Images Selected",
+                        subtitle = "Select one or more images to convert to PDF",
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(3),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(vertical = 16.dp)
+                    ) {
+                        // Image list header
+                        item(span = { GridItemSpan(3) }) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column {
+                                    Text(
+                                        text = "Selected Images (${selectedImages.size})",
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    if (hasOrderChanged) {
+                                        Text(
+                                            text = "Order modified",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                }
+
+                                Row {
+                                    if (hasOrderChanged) {
+                                        TextButton(
+                                            onClick = {
+                                                selectedImages = selectedImages.sortedBy { it.originalIndex }
+                                                selectedItemIndex = null
+                                            }
+                                        ) {
+                                            Text("Reset")
+                                        }
+                                    }
+                                    TextButton(
+                                        onClick = {
+                                            selectedImages = emptyList()
+                                            selectedItemIndex = null
+                                        }
+                                    ) {
+                                        Text("Clear All")
+                                    }
+                                }
+                            }
+                        }
+
+                        // Image list
+                        itemsIndexed(
+                            items = selectedImages,
+                            key = { index, image -> "${image.uri}-${image.originalIndex}" }
+                        ) { index, image ->
+                            ImagePreviewCard(
+                                image = image,
+                                currentPosition = index + 1,
+                                isSelected = selectedItemIndex == index,
+                                canMoveUp = index > 0,
+                                canMoveDown = index < selectedImages.lastIndex,
+                                onRemove = {
+                                    selectedImages = selectedImages.toMutableList().apply {
+                                        removeAt(index)
+                                    }
+                                    if (selectedItemIndex == index) {
+                                        selectedItemIndex = null
+                                    } else if (selectedItemIndex != null && selectedItemIndex!! > index) {
+                                        selectedItemIndex = selectedItemIndex!! - 1
+                                    }
+                                },
+                                onCrop = {
+                                    // Launch crop for this image
+                                    cropImageIndex = index
+                                    val cropIntent = CropHelper.getCropIntent(
+                                        context = context,
+                                        sourceUri = image.uri,
+                                        aspectRatio = null, // Free crop
+                                        maxSize = 2048
+                                    )
+                                    cropLauncher.launch(cropIntent)
+                                },
+                                onSelect = {
+                                    selectedItemIndex = if (selectedItemIndex == index) null else index
+                                },
+                                onMoveUp = {
+                                    if (index > 0) {
+                                        selectedImages = selectedImages.toMutableList().apply {
+                                            val item = removeAt(index)
+                                            add(index - 1, item)
+                                        }
+                                        selectedItemIndex = index - 1
+                                    }
+                                },
+                                onMoveDown = {
+                                    if (index < selectedImages.lastIndex) {
+                                        selectedImages = selectedImages.toMutableList().apply {
+                                            val item = removeAt(index)
+                                            add(index + 1, item)
+                                        }
+                                        selectedItemIndex = index + 1
+                                    }
+                                },
+                                onMoveToFirst = {
+                                    if (index > 0) {
+                                        selectedImages = selectedImages.toMutableList().apply {
+                                            val item = removeAt(index)
+                                            add(0, item)
+                                        }
+                                        selectedItemIndex = 0
+                                    }
+                                },
+                                onMoveToLast = {
+                                    if (index < selectedImages.lastIndex) {
+                                        selectedImages = selectedImages.toMutableList().apply {
+                                            val item = removeAt(index)
+                                            add(this.size, item)
+                                        }
+                                        selectedItemIndex = selectedImages.lastIndex
+                                    }
+                                }
+                            )
+                        }
+
+                        // Add more button
+                        item(span = { GridItemSpan(3) }) {
+                            OutlinedButton(
+                                onClick = {
+                                    pickImagesLauncher.launch(arrayOf("image/*"))
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Icon(Icons.Default.Add, contentDescription = null)
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Add More Images")
+                            }
+                        }
+
+                        // Settings section
+                        item(span = { GridItemSpan(3) }) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "Settings",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        // Page size selection
+                        item(span = { GridItemSpan(3) }) {
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                )
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp)
+                                ) {
+                                    Text(
+                                        text = "Page Size",
+                                        style = MaterialTheme.typography.labelLarge,
+                                        fontWeight = FontWeight.Medium
+                                    )
+
+                                    Spacer(modifier = Modifier.height(12.dp))
+
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        PageSize.entries.forEach { size ->
+                                            FilterChip(
+                                                selected = pageSize == size,
+                                                onClick = { pageSize = size },
+                                                label = { Text(size.name.replace("_", " ")) }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Quality slider
+                        item(span = { GridItemSpan(3) }) {
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                )
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp)
+                                ) {
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween
+                                    ) {
+                                        Text(
+                                            text = "Image Quality",
+                                            style = MaterialTheme.typography.labelLarge,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                        Text(
+                                            text = "${quality.toInt()}%",
+                                            style = MaterialTheme.typography.labelLarge,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.height(8.dp))
+
+                                    Slider(
+                                        value = quality,
+                                        onValueChange = { quality = it },
+                                        valueRange = 20f..100f,
+                                        steps = 7
+                                    )
+
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween
+                                    ) {
+                                        Text(
+                                            text = "Smaller file",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        Text(
+                                            text = "Better quality",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Progress overlay
+                if (isProcessing) {
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = true,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                        modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp)
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                OperationProgress(
+                                    progress = progress,
+                                    message = "Converting images..."
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Bottom action area
+            Surface(
+                modifier = Modifier.fillMaxWidth()
+                    .navigationBarsPadding(),
+                tonalElevation = 3.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    if (selectedImages.isEmpty()) {
+                        ActionButton(
+                            text = "Select Images",
+                            onClick = {
+                                pickImagesLauncher.launch(arrayOf("image/*"))
+                            },
+                            icon = Icons.Default.Image
+                        )
+                    } else {
+                        // Save location option
+                        SaveLocationSelector(
+                            useCustomLocation = useCustomLocation,
+                            onUseCustomLocationChange = { useCustomLocation = it }
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        ActionButton(
+                            text = "Convert to PDF",
+                            onClick = {
+                                if (useCustomLocation) {
+                                    val fileName = FileManager.generateOutputFileName("images")
+                                    savePdfLauncher.launch(fileName)
+                                } else {
+                                    convertWithDefaultLocation()
+                                }
+                            },
+                            isLoading = isProcessing,
+                            icon = Icons.Default.Transform
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // Result dialog with View option
+    if (showResult) {
+        ResultDialog(
+            isSuccess = resultSuccess,
+            title = if (resultSuccess) "Conversion Complete" else "Conversion Failed",
+            message = resultMessage,
+            onDismiss = {
+                showResult = false
+                resultUri = null
+            },
+            onAction = resultUri?.let { uri ->
+                { scope.launch(Dispatchers.IO) { FileOpener.openPdf(context, uri) } }
+            },
+            actionText = "Open PDF"
+        )
+    }
+}
+
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImagePreviewCard(
+    image: ImageInfo,
+    currentPosition: Int,
+    isSelected: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onSelect: () -> Unit,
+    onRemove: () -> Unit,
+    onCrop: (() -> Unit)? = null,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onMoveToFirst: () -> Unit,
+    onMoveToLast: () -> Unit
+) {
+    val hasChanged = image.originalIndex + 1 != currentPosition
+
+    Card(
+        onClick = onSelect,
+        modifier = Modifier
+            .aspectRatio(1f)
+            .then(
+                if (isSelected) {
+                    Modifier.border(
+                        width = 3.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                } else Modifier
+            ),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            }
+        )
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            AsyncImage(
+                model = image.uri,
+                contentDescription = image.name,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
+            )
+
+            // Position badge (top-left)
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(6.dp),
+                shape = CircleShape,
+                color = if (hasChanged) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
+                }
+            ) {
+                Text(
+                    text = "$currentPosition",
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = if (hasChanged) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                )
+            }
+
+            // Original page number (if different)
+            if (hasChanged) {
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(6.dp),
+                    shape = RoundedCornerShape(4.dp),
+                    color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.9f)
+                ) {
+                    Text(
+                        text = "was ${image.originalIndex + 1}",
+                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                }
+            }
+
+            // Move controls (when selected)
+            if (isSelected) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .background(
+                            MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                        )
+                        .padding(2.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // Row 1: Actions
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (onCrop != null) {
+                            IconButton(onClick = onCrop, modifier = Modifier.size(28.dp)) {
+                                Icon(Icons.Default.Crop, contentDescription = "Crop", modifier = Modifier.size(18.dp))
+                            }
+                        }
+                        IconButton(onClick = onRemove, modifier = Modifier.size(28.dp)) {
+                            Icon(Icons.Default.Delete, contentDescription = "Remove", tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(18.dp))
+                        }
+                    }
+                    // Row 2: Navigation
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        IconButton(onClick = onMoveToFirst, enabled = canMoveUp, modifier = Modifier.size(28.dp)) {
+                            Icon(Icons.Default.KeyboardDoubleArrowUp, contentDescription = "First", modifier = Modifier.size(18.dp))
+                        }
+                        IconButton(onClick = onMoveUp, enabled = canMoveUp, modifier = Modifier.size(28.dp)) {
+                            Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Up", modifier = Modifier.size(18.dp))
+                        }
+                        IconButton(onClick = onMoveDown, enabled = canMoveDown, modifier = Modifier.size(28.dp)) {
+                            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Down", modifier = Modifier.size(18.dp))
+                        }
+                        IconButton(onClick = onMoveToLast, enabled = canMoveDown, modifier = Modifier.size(28.dp)) {
+                            Icon(Icons.Default.KeyboardDoubleArrowDown, contentDescription = "Last", modifier = Modifier.size(18.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/ScanToPdfScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/ScanToPdfScreen.kt
@@ -681,7 +681,8 @@ private fun CameraScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
-                .padding(32.dp),
+                .padding(32.dp)
+                .navigationBarsPadding(),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt.orig
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt.orig
@@ -1,0 +1,319 @@
+package com.yourname.pdftoolkit.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.FileProvider
+import com.yalantis.ucrop.UCrop
+import com.yalantis.ucrop.UCropActivity
+import java.io.File
+import java.io.FileOutputStream
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+
+/**
+ * Helper for uCrop integration - lightweight image cropping.
+ *
+ * Supports:
+ * - Free crop
+ * - Fixed aspect ratios (A4, Letter, Square, etc.)
+ * - Custom aspect ratios
+ *
+ * Usage:
+ * - Call from Image → PDF flow for optional cropping
+ * - Call from manual image edit screen
+ *
+ * NOTE: This helper properly handles content:// URIs by copying them to cache
+ * and using FileProvider URIs that uCrop can read/write on Android 10+.
+ */
+object CropHelper {
+
+    private const val TAG = "CropHelper"
+
+    /**
+     * Aspect ratio presets for cropping.
+     */
+    enum class CropAspectRatio(val x: Float, val y: Float, val displayName: String) {
+        FREE(0f, 0f, "Free"),
+        SQUARE(1f, 1f, "Square"),
+        RATIO_3_2(3f, 2f, "3:2"),
+        RATIO_4_3(4f, 3f, "4:3"),
+        RATIO_16_9(16f, 9f, "16:9"),
+        A4_PORTRAIT(210f, 297f, "A4 Portrait"),
+        A4_LANDSCAPE(297f, 210f, "A4 Landscape"),
+        LETTER_PORTRAIT(8.5f, 11f, "Letter Portrait"),
+        LETTER_LANDSCAPE(11f, 8.5f, "Letter Landscape")
+    }
+
+    /**
+     * Get the crop intent for an Activity result launcher.
+     *
+     * IMPORTANT: This copies the source image to cache if it's a content:// URI
+     * because uCrop cannot directly access content:// URIs from other apps.
+     */
+    fun getCropIntent(
+        context: Context,
+        sourceUri: Uri,
+        aspectRatio: CropAspectRatio? = null,
+        maxSize: Int = 2048
+    ): Intent {
+        try {
+            // Step 1: Prepare source URI - copy to cache if it's a content:// URI
+            val localSourceUri = prepareSourceUri(context, sourceUri)
+
+            // Step 2: Create destination file and get FileProvider URI
+            val destinationFile = createDestinationFile(context)
+            val destinationUri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                destinationFile
+            )
+
+            Log.d(TAG, "Source URI: $localSourceUri")
+            Log.d(TAG, "Destination URI: $destinationUri")
+
+            // Step 3: Configure uCrop options
+            val options = UCrop.Options().apply {
+                // Use app theme colors
+                setToolbarColor(Color.parseColor("#1A1A2E"))
+                setStatusBarColor(Color.parseColor("#0F0F1A"))
+                setActiveControlsWidgetColor(Color.parseColor("#4A90D9"))
+                setToolbarWidgetColor(Color.WHITE)
+
+                // Compression settings
+                setCompressionFormat(android.graphics.Bitmap.CompressFormat.JPEG)
+                setCompressionQuality(90)
+
+                // UI settings
+                setFreeStyleCropEnabled(aspectRatio == null || aspectRatio == CropAspectRatio.FREE)
+                setShowCropFrame(true)
+                setShowCropGrid(true)
+                setCropGridRowCount(3)
+                setCropGridColumnCount(3)
+                setHideBottomControls(false)
+
+                // Gesture settings
+                setAllowedGestures(
+                    UCropActivity.SCALE,
+                    UCropActivity.ROTATE,
+                    UCropActivity.ALL
+                )
+
+                // Max size
+                setMaxBitmapSize(maxSize)
+            }
+
+            // Step 4: Create uCrop intent
+            val uCrop = UCrop.of(localSourceUri, destinationUri)
+                .withOptions(options)
+                .withMaxResultSize(maxSize, maxSize)
+
+            // Set aspect ratio if specified
+            if (aspectRatio != null && aspectRatio != CropAspectRatio.FREE) {
+                uCrop.withAspectRatio(aspectRatio.x, aspectRatio.y)
+            }
+
+            // Step 5: Get intent and add URI permissions
+            val intent = uCrop.getIntent(context)
+
+            // Grant read permission to source and write permission to destination
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+
+            // Pass edge to edge intent flag
+            // intent.putExtra("isEdgeToEdge", true) // Unused
+
+            return intent
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create crop intent", e)
+            throw e
+        }
+    }
+
+    /**
+     * Prepare source URI for uCrop.
+     * If it's a content:// URI from another app, copy it to local cache first.
+     */
+    private fun prepareSourceUri(context: Context, sourceUri: Uri): Uri {
+        // Check if it's already a file:// URI or our own FileProvider URI
+        if (sourceUri.scheme == "file") {
+            // Convert to FileProvider URI
+            val file = File(sourceUri.path ?: return sourceUri)
+            return FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                file
+            )
+        }
+
+        // Check if it's our own FileProvider
+        val authority = sourceUri.authority ?: ""
+        if (authority.contains(context.packageName)) {
+            // It's our own FileProvider URI, return as-is
+            return sourceUri
+        }
+
+        // It's a content:// URI from another app - copy to cache
+        return try {
+            val timestamp = System.currentTimeMillis()
+            val cacheFile = File(context.cacheDir, "crop_source_${timestamp}.jpg")
+
+            context.contentResolver.openInputStream(sourceUri)?.use { input ->
+                FileOutputStream(cacheFile).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: throw Exception("Cannot open source URI")
+
+            Log.d(TAG, "Copied source to cache: ${cacheFile.absolutePath}")
+
+            // Return FileProvider URI for the cached file
+            FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                cacheFile
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to copy source to cache", e)
+            // Return original URI as fallback (may fail on uCrop)
+            sourceUri
+        }
+    }
+
+    /**
+     * Create destination file for cropped image.
+     */
+    private fun createDestinationFile(context: Context): File {
+        val timestamp = System.currentTimeMillis()
+        return File(context.cacheDir, "cropped_${timestamp}.jpg")
+    }
+
+    /**
+     * Create a crop intent with specified options.
+     * DEPRECATED: Use getCropIntent instead for proper content:// URI handling.
+     */
+    @Deprecated("Use getCropIntent instead", ReplaceWith("getCropIntent(context, sourceUri, aspectRatio, maxWidth)"))
+    fun createCropIntent(
+        context: Context,
+        sourceUri: Uri,
+        aspectRatio: CropAspectRatio? = null,
+        maxWidth: Int = 2048,
+        maxHeight: Int = 2048
+    ): UCrop {
+        val localSourceUri = prepareSourceUri(context, sourceUri)
+        val destinationFile = createDestinationFile(context)
+        val destinationUri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.provider",
+            destinationFile
+        )
+
+        val options = UCrop.Options().apply {
+            setToolbarColor(Color.parseColor("#1A1A2E"))
+            setStatusBarColor(Color.parseColor("#0F0F1A"))
+            setActiveControlsWidgetColor(Color.parseColor("#4A90D9"))
+            setToolbarWidgetColor(Color.WHITE)
+            setCompressionFormat(android.graphics.Bitmap.CompressFormat.JPEG)
+            setCompressionQuality(90)
+            setFreeStyleCropEnabled(aspectRatio == null || aspectRatio == CropAspectRatio.FREE)
+            setShowCropFrame(true)
+            setShowCropGrid(true)
+            setCropGridRowCount(3)
+            setCropGridColumnCount(3)
+            setHideBottomControls(false)
+            setAllowedGestures(
+                UCropActivity.SCALE,
+                UCropActivity.ROTATE,
+                UCropActivity.ALL
+            )
+            setMaxBitmapSize(maxWidth.coerceAtLeast(maxHeight))
+        }
+
+        val uCrop = UCrop.of(localSourceUri, destinationUri)
+            .withOptions(options)
+            .withMaxResultSize(maxWidth, maxHeight)
+
+        if (aspectRatio != null && aspectRatio != CropAspectRatio.FREE) {
+            uCrop.withAspectRatio(aspectRatio.x, aspectRatio.y)
+        }
+
+        return uCrop
+    }
+
+    /**
+     * Start crop activity.
+     */
+    fun startCrop(
+        activity: Activity,
+        sourceUri: Uri,
+        requestCode: Int,
+        aspectRatio: CropAspectRatio? = null,
+        maxSize: Int = 2048
+    ) {
+        val intent = getCropIntent(
+            context = activity,
+            sourceUri = sourceUri,
+            aspectRatio = aspectRatio,
+            maxSize = maxSize
+        )
+        activity.startActivityForResult(intent, requestCode)
+    }
+
+    /**
+     * Parse crop result from activity result.
+     *
+     * @param resultCode Activity result code
+     * @param data Intent data
+     * @return Cropped image URI or null on failure/cancellation
+     */
+    fun getResultUri(resultCode: Int, data: Intent?): Uri? {
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            return UCrop.getOutput(data)
+        }
+        return null
+    }
+
+    /**
+     * Get error from failed crop operation.
+     */
+    fun getError(data: Intent?): Throwable? {
+        return data?.let { UCrop.getError(it) }
+    }
+
+    /**
+     * Check if the result indicates a crop operation was cancelled.
+     */
+    fun isCancelled(resultCode: Int): Boolean {
+        return resultCode == Activity.RESULT_CANCELED
+    }
+
+    /**
+     * Clean up cropped images from cache.
+     */
+    fun cleanupCroppedFiles(context: Context) {
+        context.cacheDir.listFiles()?.forEach { file ->
+            if ((file.name.startsWith("cropped_") || file.name.startsWith("crop_source_"))
+                && file.name.endsWith(".jpg")) {
+                file.delete()
+            }
+        }
+    }
+
+    /**
+     * Get the file from a cropped URI.
+     */
+    fun getFileFromUri(uri: Uri): File? {
+        return uri.path?.let { File(it) }
+    }
+
+    /**
+     * Delete a specific cropped file.
+     */
+    fun deleteCroppedFile(uri: Uri): Boolean {
+        return getFileFromUri(uri)?.delete() ?: false
+    }
+}

--- a/app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt.patch
+++ b/app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt.patch
@@ -1,0 +1,21 @@
+--- app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt
++++ app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt
+@@ -10,6 +10,8 @@
+ import com.yalantis.ucrop.UCrop
+ import com.yalantis.ucrop.UCropActivity
+ import java.io.File
+ import java.io.FileOutputStream
++import androidx.core.view.ViewCompat
++import androidx.core.view.WindowInsetsCompat
+
+
+ /**
+@@ -124,6 +126,9 @@
+             // Grant read permission to source and write permission to destination
+             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+             intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
++
++            // Pass edge to edge intent flag
++            // intent.putExtra("isEdgeToEdge", true) // Unused
+
+             return intent

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.UCropActivity" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- android:windowOptOutEdgeToEdgeEnforcement only works on API 35+ -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,4 +7,13 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
+
+    <style name="Theme.UCropActivity" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Prevent edge-to-edge layout inside UCrop to fix overlapping with system navigation bar -->
+        <item name="android:windowLayoutInDisplayCutoutMode">default</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">true</item>
+    </style>
 </resources>

--- a/fix_crophelper.patch
+++ b/fix_crophelper.patch
@@ -1,0 +1,21 @@
+--- app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt
++++ app/src/main/java/com/yourname/pdftoolkit/util/CropHelper.kt
+@@ -10,8 +10,6 @@
+ import com.yalantis.ucrop.UCrop
+ import com.yalantis.ucrop.UCropActivity
+ import java.io.File
+ import java.io.FileOutputStream
+-import androidx.core.view.ViewCompat
+-import androidx.core.view.WindowInsetsCompat
+
+
+ /**
+@@ -126,9 +124,6 @@
+             // Grant read permission to source and write permission to destination
+             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+             intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+-
+-            // Pass edge to edge intent flag
+-            // intent.putExtra("isEdgeToEdge", true) // Unused
+
+             return intent

--- a/fix_surface_padding.patch
+++ b/fix_surface_padding.patch
@@ -1,0 +1,36 @@
+--- app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt
++++ app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt
+@@ -557,8 +557,7 @@
+
+             // Bottom action area
+             Surface(
+-                modifier = Modifier.fillMaxWidth()
+-                    .navigationBarsPadding(),
++                modifier = Modifier.fillMaxWidth(),
+                 tonalElevation = 3.dp
+             ) {
+                 Column(
+                     modifier = Modifier
+                         .fillMaxWidth()
++                        .navigationBarsPadding()
+                         .padding(16.dp)
+                 ) {
+                     if (selectedImages.isEmpty()) {
+--- app/src/main/java/com/yourname/pdftoolkit/ui/screens/ImageToolsScreen.kt
++++ app/src/main/java/com/yourname/pdftoolkit/ui/screens/ImageToolsScreen.kt
+@@ -783,8 +783,7 @@
+
+             // Bottom action area
+             Surface(
+-                modifier = Modifier.fillMaxWidth()
+-                    .navigationBarsPadding(),
++                modifier = Modifier.fillMaxWidth(),
+                 tonalElevation = 3.dp
+             ) {
+                 Column(
+                     modifier = Modifier
+                         .fillMaxWidth()
++                        .navigationBarsPadding()
+                         .padding(16.dp)
+                 ) {
+                     if (selectedImages.isEmpty()) {

--- a/test_convert_patch.patch
+++ b/test_convert_patch.patch
@@ -1,0 +1,11 @@
+--- app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt
++++ app/src/main/java/com/yourname/pdftoolkit/ui/screens/ConvertScreen.kt
+@@ -557,7 +557,8 @@
+             // Bottom action area
+             Surface(
+-                modifier = Modifier.fillMaxWidth(),
++                modifier = Modifier.fillMaxWidth()
++                    .navigationBarsPadding(),
+                 tonalElevation = 3.dp
+             ) {
+                 Column(

--- a/test_image_tools_patch.patch
+++ b/test_image_tools_patch.patch
@@ -1,0 +1,12 @@
+--- app/src/main/java/com/yourname/pdftoolkit/ui/screens/ImageToolsScreen.kt
++++ app/src/main/java/com/yourname/pdftoolkit/ui/screens/ImageToolsScreen.kt
+@@ -783,7 +783,8 @@
+
+             // Bottom action area
+             Surface(
+-                modifier = Modifier.fillMaxWidth(),
++                modifier = Modifier.fillMaxWidth()
++                    .navigationBarsPadding(),
+                 tonalElevation = 3.dp
+             ) {
+                 Column(

--- a/test_scan_patch.patch
+++ b/test_scan_patch.patch
@@ -1,0 +1,12 @@
+--- app/src/main/java/com/yourname/pdftoolkit/ui/screens/ScanToPdfScreen.kt
++++ app/src/main/java/com/yourname/pdftoolkit/ui/screens/ScanToPdfScreen.kt
+@@ -681,7 +681,8 @@
+             modifier = Modifier
+                 .fillMaxWidth()
+                 .align(Alignment.BottomCenter)
+-                .padding(32.dp),
++                .padding(32.dp)
++                .navigationBarsPadding(),
+             horizontalArrangement = Arrangement.SpaceEvenly,
+             verticalAlignment = Alignment.CenterVertically
+         ) {

--- a/test_ucrop_manifest_patch.patch
+++ b/test_ucrop_manifest_patch.patch
@@ -1,0 +1,10 @@
+--- app/src/main/AndroidManifest.xml
++++ app/src/main/AndroidManifest.xml
+@@ -128,7 +128,7 @@
+         <activity
+             android:name="com.yalantis.ucrop.UCropActivity"
+             android:screenOrientation="portrait"
+-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
++            android:theme="@style/Theme.UCropActivity"/>
+
+     </application>


### PR DESCRIPTION
This change addresses an issue where the bottom toolbar on the photo edit and crop screens was overlapping with the system navigation bar, primarily affecting devices using 3-button navigation mode on targetSdk 35+ (Android 15 edge-to-edge enforcement).

The fix applies to both the third-party UCrop UI (by utilizing a custom theme with Android 15's `windowOptOutEdgeToEdgeEnforcement`) and the native Compose screens (`ScanToPdfScreen`, `ConvertScreen`, `ImageToolsScreen`), where `navigationBarsPadding()` is now properly applied to the bottom toolbars to provide safe padding.

---
*PR created automatically by Jules for task [11624148070702986805](https://jules.google.com/task/11624148070702986805) started by @Karna14314*