### PR TITLE
fix: translate fill forms strings across all locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -590,14 +590,14 @@
     <string name="split_from">من</string>
     <string name="split_to">إلى</string>
     <string name="split_page_numbers">أرقام الصفحات</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">تحديد نموذج PDF</string>
+    <string name="fill_no_form_fields_found">لم يتم العثور على حقول نموذج</string>
+    <string name="fill_no_fillable_fields_found">لا يحتوي ملف PDF هذا على حقول نماذج قابلة للتعبئة.</string>
+    <string name="fill_fields_found">تم العثور على %1$d حقول قابلة للتعبئة</string>
+    <string name="fill_form_fields_title">حقول النموذج</string>
+    <string name="fill_flatten_after_filling">تسطيح بعد التعبئة</string>
+    <string name="fill_make_non_editable">جعل الحقول غير قابلة للتحرير</string>
+    <string name="fill_form_filled">تم تعبئة النموذج!</string>
+    <string name="fill_fields_updated">تم تحديث %1$d حقول</string>
+    <string name="fill_no_editable_fields">لا يحتوي هذا النموذج على حقول قابلة للتحرير</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -586,14 +586,14 @@ Gespeichert unter: %1$s</string>
     <string name="split_from">Von</string>
     <string name="split_to">Bis</string>
     <string name="split_page_numbers">Seitennummern</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF-Formular auswählen</string>
+    <string name="fill_no_form_fields_found">Keine Formularfelder gefunden</string>
+    <string name="fill_no_fillable_fields_found">Diese PDF-Datei enthält keine ausfüllbaren Formularfelder.</string>
+    <string name="fill_fields_found">%1$d ausfüllbare Felder gefunden</string>
+    <string name="fill_form_fields_title">Formularfelder</string>
+    <string name="fill_flatten_after_filling">Nach dem Ausfüllen reduzieren</string>
+    <string name="fill_make_non_editable">Felder nicht bearbeitbar machen</string>
+    <string name="fill_form_filled">Formular ausgefüllt!</string>
+    <string name="fill_fields_updated">%1$d Felder aktualisiert</string>
+    <string name="fill_no_editable_fields">Dieses Formular hat keine bearbeitbaren Felder</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -590,14 +590,14 @@ Guardado en: %1$s</string>
     <string name="split_from">Desde</string>
     <string name="split_to">Hasta</string>
     <string name="split_page_numbers">Números de página</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">Seleccionar formulario PDF</string>
+    <string name="fill_no_form_fields_found">No se encontraron campos de formulario</string>
+    <string name="fill_no_fillable_fields_found">Este PDF no contiene campos de formulario rellenables.</string>
+    <string name="fill_fields_found">%1$d campos rellenables encontrados</string>
+    <string name="fill_form_fields_title">Campos de formulario</string>
+    <string name="fill_flatten_after_filling">Acoplar después de rellenar</string>
+    <string name="fill_make_non_editable">Hacer campos no editables</string>
+    <string name="fill_form_filled">¡Formulario rellenado!</string>
+    <string name="fill_fields_updated">%1$d campos actualizados</string>
+    <string name="fill_no_editable_fields">Este formulario no tiene campos editables</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -590,14 +590,14 @@ Enregistré dans : %1$s</string>
     <string name="split_from">De</string>
     <string name="split_to">À</string>
     <string name="split_page_numbers">Numéros de page</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">Sélectionner un formulaire PDF</string>
+    <string name="fill_no_form_fields_found">Aucun champ de formulaire trouvé</string>
+    <string name="fill_no_fillable_fields_found">Ce PDF ne contient pas de champs de formulaire remplissables.</string>
+    <string name="fill_fields_found">%1$d champs remplissables trouvés</string>
+    <string name="fill_form_fields_title">Champs de formulaire</string>
+    <string name="fill_flatten_after_filling">Aplatir après remplissage</string>
+    <string name="fill_make_non_editable">Rendre les champs non modifiables</string>
+    <string name="fill_form_filled">Formulaire rempli !</string>
+    <string name="fill_fields_updated">%1$d champs mis à jour</string>
+    <string name="fill_no_editable_fields">Ce formulaire n\'a pas de champs modifiables</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -586,14 +586,14 @@
     <string name="split_from">से</string>
     <string name="split_to">तक</string>
     <string name="split_page_numbers">पृष्ठ संख्याएं</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF फ़ॉर्म चुनें</string>
+    <string name="fill_no_form_fields_found">कोई फ़ॉर्म फ़ील्ड नहीं मिला</string>
+    <string name="fill_no_fillable_fields_found">इस PDF में भरने योग्य फ़ॉर्म फ़ील्ड नहीं हैं।</string>
+    <string name="fill_fields_found">%1$d भरने योग्य फ़ील्ड मिले</string>
+    <string name="fill_form_fields_title">फ़ॉर्म फ़ील्ड</string>
+    <string name="fill_flatten_after_filling">भरने के बाद फ़्लैट करें</string>
+    <string name="fill_make_non_editable">फ़ील्ड को संपादन योग्य न बनाएं</string>
+    <string name="fill_form_filled">फ़ॉर्म भर गया!</string>
+    <string name="fill_fields_updated">%1$d फ़ील्ड अपडेट किए गए</string>
+    <string name="fill_no_editable_fields">इस फ़ॉर्म में कोई संपादन योग्य फ़ील्ड नहीं है</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -590,14 +590,14 @@ Disimpan ke: %1$s</string>
     <string name="split_from">Dari</string>
     <string name="split_to">Ke</string>
     <string name="split_page_numbers">Nomor Halaman</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">Pilih Formulir PDF</string>
+    <string name="fill_no_form_fields_found">Tidak Ada Kolom Formulir Ditemukan</string>
+    <string name="fill_no_fillable_fields_found">PDF ini tidak berisi kolom formulir yang dapat diisi.</string>
+    <string name="fill_fields_found">%1$d kolom yang dapat diisi ditemukan</string>
+    <string name="fill_form_fields_title">Kolom Formulir</string>
+    <string name="fill_flatten_after_filling">Ratakan Setelah Mengisi</string>
+    <string name="fill_make_non_editable">Jadikan kolom tidak dapat diedit</string>
+    <string name="fill_form_filled">Formulir Terisi!</string>
+    <string name="fill_fields_updated">%1$d kolom diperbarui</string>
+    <string name="fill_no_editable_fields">Formulir ini tidak memiliki kolom yang dapat diedit</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -590,14 +590,14 @@
     <string name="split_from">から</string>
     <string name="split_to">まで</string>
     <string name="split_page_numbers">ページ番号</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDFフォームを選択</string>
+    <string name="fill_no_form_fields_found">フォームフィールドが見つかりません</string>
+    <string name="fill_no_fillable_fields_found">このPDFには入力可能なフォームフィールドが含まれていません。</string>
+    <string name="fill_fields_found">%1$d個の入力可能フィールドが見つかりました</string>
+    <string name="fill_form_fields_title">フォームフィールド</string>
+    <string name="fill_flatten_after_filling">入力後にフラット化</string>
+    <string name="fill_make_non_editable">フィールドを編集不可にする</string>
+    <string name="fill_form_filled">フォームに入力しました！</string>
+    <string name="fill_fields_updated">%1$d個のフィールドを更新しました</string>
+    <string name="fill_no_editable_fields">このフォームには編集可能なフィールドがありません</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -590,14 +590,14 @@
     <string name="split_from">시작</string>
     <string name="split_to">끝</string>
     <string name="split_page_numbers">페이지 번호</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF 양식 선택</string>
+    <string name="fill_no_form_fields_found">양식 필드를 찾을 수 없음</string>
+    <string name="fill_no_fillable_fields_found">이 PDF에는 입력 가능한 양식 필드가 없습니다.</string>
+    <string name="fill_fields_found">%1$d개의 입력 가능한 필드 찾음</string>
+    <string name="fill_form_fields_title">양식 필드</string>
+    <string name="fill_flatten_after_filling">입력 후 병합</string>
+    <string name="fill_make_non_editable">필드를 편집할 수 없게 만들기</string>
+    <string name="fill_form_filled">양식 입력 완료!</string>
+    <string name="fill_fields_updated">%1$d개의 필드 업데이트됨</string>
+    <string name="fill_no_editable_fields">이 양식에는 편집 가능한 필드가 없습니다</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -586,14 +586,14 @@ Salvo em: %1$s</string>
     <string name="split_from">De</string>
     <string name="split_to">Até</string>
     <string name="split_page_numbers">Números de Página</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">Selecionar formulário PDF</string>
+    <string name="fill_no_form_fields_found">Nenhum campo de formulário encontrado</string>
+    <string name="fill_no_fillable_fields_found">Este PDF não contém campos de formulário preenchíveis.</string>
+    <string name="fill_fields_found">%1$d campos preenchíveis encontrados</string>
+    <string name="fill_form_fields_title">Campos de formulário</string>
+    <string name="fill_flatten_after_filling">Achatar após preencher</string>
+    <string name="fill_make_non_editable">Tornar os campos não editáveis</string>
+    <string name="fill_form_filled">Formulário preenchido!</string>
+    <string name="fill_fields_updated">%1$d campos atualizados</string>
+    <string name="fill_no_editable_fields">Este formulário não possui campos editáveis</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -590,14 +590,14 @@
     <string name="split_from">С</string>
     <string name="split_to">По</string>
     <string name="split_page_numbers">Номера страниц</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">Выбрать PDF-форму</string>
+    <string name="fill_no_form_fields_found">Поля формы не найдены</string>
+    <string name="fill_no_fillable_fields_found">В этом PDF нет заполняемых полей формы.</string>
+    <string name="fill_fields_found">Найдено %1$d заполняемых полей</string>
+    <string name="fill_form_fields_title">Поля формы</string>
+    <string name="fill_flatten_after_filling">Объединить после заполнения</string>
+    <string name="fill_make_non_editable">Сделать поля нередактируемыми</string>
+    <string name="fill_form_filled">Форма заполнена!</string>
+    <string name="fill_fields_updated">Обновлено %1$d полей</string>
+    <string name="fill_no_editable_fields">В этой форме нет редактируемых полей</string>
 </resources>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -590,14 +590,14 @@
     <string name="split_from">Dan</string>
     <string name="split_to">Çenli</string>
     <string name="split_page_numbers">Sahypa belgileri</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF formany saýlaň</string>
+    <string name="fill_no_form_fields_found">Forma meýdanlary tapylmady</string>
+    <string name="fill_no_fillable_fields_found">Bu PDF-de dolduryp bolýan forma meýdanlary ýok.</string>
+    <string name="fill_fields_found">%1$d dolduryp bolýan meýdan tapyldy</string>
+    <string name="fill_form_fields_title">Forma meýdanlary</string>
+    <string name="fill_flatten_after_filling">Dolduransoň tekizläň</string>
+    <string name="fill_make_non_editable">Meýdanlary üýtgedip bolmaýan ediň</string>
+    <string name="fill_form_filled">Forma dolduryldy!</string>
+    <string name="fill_fields_updated">%1$d meýdan täzelendi</string>
+    <string name="fill_no_editable_fields">Bu formada üýtgedip bolýan meýdan ýok</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -590,14 +590,14 @@ Kaydedildi: %1$s</string>
     <string name="split_from">Başlangıç</string>
     <string name="split_to">Bitiş</string>
     <string name="split_page_numbers">Sayfa Numaraları</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF Formu Seç</string>
+    <string name="fill_no_form_fields_found">Form Alanı Bulunamadı</string>
+    <string name="fill_no_fillable_fields_found">Bu PDF doldurulabilir form alanları içermiyor.</string>
+    <string name="fill_fields_found">%1$d doldurulabilir alan bulundu</string>
+    <string name="fill_form_fields_title">Form Alanları</string>
+    <string name="fill_flatten_after_filling">Doldurduktan Sonra Düzleştir</string>
+    <string name="fill_make_non_editable">Alanları düzenlenemez yap</string>
+    <string name="fill_form_filled">Form Dolduruldu!</string>
+    <string name="fill_fields_updated">%1$d alan güncellendi</string>
+    <string name="fill_no_editable_fields">Bu formda düzenlenebilir alan yok</string>
 </resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -590,14 +590,14 @@ Saqlandi: %1$s</string>
     <string name="split_from">Dan</string>
     <string name="split_to">Gacha</string>
     <string name="split_page_numbers">Sahifa Raqamlari</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">PDF shaklini tanlang</string>
+    <string name="fill_no_form_fields_found">Shakl maydonlari topilmadi</string>
+    <string name="fill_no_fillable_fields_found">Ushbu PDF-da to\'ldiriladigan shakl maydonlari yo\'q.</string>
+    <string name="fill_fields_found">%1$d to\'ldiriladigan maydon topildi</string>
+    <string name="fill_form_fields_title">Shakl maydonlari</string>
+    <string name="fill_flatten_after_filling">To\'ldirgandan so\'ng tekislash</string>
+    <string name="fill_make_non_editable">Maydonlarni tahrirlab bo\'lmaydigan qilish</string>
+    <string name="fill_form_filled">Shakl to\'ldirildi!</string>
+    <string name="fill_fields_updated">%1$d maydon yangilandi</string>
+    <string name="fill_no_editable_fields">Ushbu shaklda tahrirlanadigan maydonlar yo\'q</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -586,14 +586,14 @@
     <string name="split_from">从</string>
     <string name="split_to">至</string>
     <string name="split_page_numbers">页码范围</string>
-    <string name="fill_select_pdf">Select PDF Form</string>
-    <string name="fill_no_form_fields_found">No Form Fields Found</string>
-    <string name="fill_no_fillable_fields_found">This PDF doesn\'t contain fillable form fields.</string>
-    <string name="fill_fields_found">%1$d fillable fields found</string>
-    <string name="fill_form_fields_title">Form Fields</string>
-    <string name="fill_flatten_after_filling">Flatten After Filling</string>
-    <string name="fill_make_non_editable">Make fields non-editable</string>
-    <string name="fill_form_filled">Form Filled!</string>
-    <string name="fill_fields_updated">%1$d fields updated</string>
-    <string name="fill_no_editable_fields">This form has no editable fields</string>
+    <string name="fill_select_pdf">选择PDF表单</string>
+    <string name="fill_no_form_fields_found">未找到表单字段</string>
+    <string name="fill_no_fillable_fields_found">此PDF不包含可填写的表单字段。</string>
+    <string name="fill_fields_found">找到 %1$d 个可填写字段</string>
+    <string name="fill_form_fields_title">表单字段</string>
+    <string name="fill_flatten_after_filling">填写后拼合</string>
+    <string name="fill_make_non_editable">使字段不可编辑</string>
+    <string name="fill_form_filled">表单已填写！</string>
+    <string name="fill_fields_updated">更新了 %1$d 个字段</string>
+    <string name="fill_no_editable_fields">此表单没有可编辑的字段</string>
 </resources>


### PR DESCRIPTION
Translated 10 Fill Forms strings across 14 locales.

Files modified:
* app/src/main/res/values-ar/strings.xml
* app/src/main/res/values-de/strings.xml
* app/src/main/res/values-es/strings.xml
* app/src/main/res/values-fr/strings.xml
* app/src/main/res/values-hi/strings.xml
* app/src/main/res/values-id/strings.xml
* app/src/main/res/values-ja/strings.xml
* app/src/main/res/values-ko/strings.xml
* app/src/main/res/values-pt-rBR/strings.xml
* app/src/main/res/values-ru/strings.xml
* app/src/main/res/values-tk/strings.xml
* app/src/main/res/values-tr/strings.xml
* app/src/main/res/values-uz/strings.xml
* app/src/main/res/values-zh/strings.xml

All 10 translations have been verified confidently. I didn't flag any of them with TODO. 

Verification output to show none of the values are identical to English base text:
[ar]: Success (0/10 strings are byte-identical to English base)
[de]: Success (0/10 strings are byte-identical to English base)
[es]: Success (0/10 strings are byte-identical to English base)
[fr]: Success (0/10 strings are byte-identical to English base)
[hi]: Success (0/10 strings are byte-identical to English base)
[id]: Success (0/10 strings are byte-identical to English base)
[ja]: Success (0/10 strings are byte-identical to English base)
[ko]: Success (0/10 strings are byte-identical to English base)
[pt-rBR]: Success (0/10 strings are byte-identical to English base)
[ru]: Success (0/10 strings are byte-identical to English base)
[tk]: Success (0/10 strings are byte-identical to English base)
[tr]: Success (0/10 strings are byte-identical to English base)
[uz]: Success (0/10 strings are byte-identical to English base)
[zh]: Success (0/10 strings are byte-identical to English base)

---
*PR created automatically by Jules for task [6553282119786126740](https://jules.google.com/task/6553282119786126740) started by @Karna14314*