### PR TITLE
feat(compress): Add Target Size compression mode

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfCompressor.kt
@@ -116,6 +116,173 @@ class PdfCompressor {
      * @param onProgress Progress callback (0.0 to 1.0)
      * @return CompressionResult with size statistics
      */
+
+    /**
+     * Iteratively compress a PDF file to reach a target size.
+     * Uses binary search to find the highest quality (lowest qualityPercent) that meets the target size.
+     * Capped at 6-8 iterations.
+     */
+    suspend fun compressPdfToTargetSize(
+        context: Context,
+        inputUri: Uri,
+        outputStream: OutputStream,
+        targetSizeBytes: Long,
+        onProgress: (Float) -> Unit = {}
+    ): Result<CompressionResult> = withContext(Dispatchers.IO) {
+        val startTime = System.currentTimeMillis()
+        var tempFile: File? = null
+        val cacheDir = File(context.cacheDir, "compress_cache")
+        if (!cacheDir.exists()) cacheDir.mkdirs()
+
+        try {
+            ensureActive()
+            onProgress(0.05f)
+
+            tempFile = File(cacheDir, "temp_target_compress_${System.currentTimeMillis()}.pdf")
+            context.contentResolver.openInputStream(inputUri)?.use { input ->
+                FileOutputStream(tempFile).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: return@withContext Result.failure(IllegalStateException("Cannot open input file"))
+
+            val originalSize = tempFile.length()
+            if (originalSize <= targetSizeBytes) {
+                onProgress(1.0f)
+                tempFile.inputStream().use { it.copyTo(outputStream) }
+                outputStream.flush()
+                return@withContext Result.success(
+                    CompressionResult(
+                        originalSize = originalSize,
+                        compressedSize = originalSize,
+                        compressionRatio = 1f,
+                        timeTakenMs = System.currentTimeMillis() - startTime,
+                        pagesProcessed = countPages(tempFile),
+                        strategyUsed = CompressionStrategy.IMAGE_OPTIMIZATION
+                    )
+                )
+            }
+
+            // Binary search setup
+            var low = 0 // Best quality
+            var high = 100 // Max compression
+            var bestFile: File? = null
+            var bestQuality = -1
+            var bestSize = Long.MAX_VALUE
+            var bestStrategy = CompressionStrategy.IMAGE_OPTIMIZATION
+            val maxIterations = 6
+            var iterationCount = 0
+
+            while (low <= high && iterationCount < maxIterations) {
+                ensureActive()
+                val mid = (low + high) / 2
+                iterationCount++
+
+                val currentProgress = 0.05f + 0.85f * (iterationCount.toFloat() / maxIterations)
+                onProgress(currentProgress)
+
+                val iterationFile = File(cacheDir, "iter_${iterationCount}_${System.currentTimeMillis()}.pdf")
+                val profile = profileFromSlider(mid) ?: profileFromLevel(CompressionLevel.MEDIUM)
+
+                var currentStrategy = CompressionStrategy.IMAGE_OPTIMIZATION
+                var optFile = tryImageOptimization(context, tempFile, profile, {})
+
+                val isOptInefficient = optFile != null && optFile.length() > originalSize * 0.85f
+
+                // Decide if we should fall back to rerender for this iteration
+                val shouldTryRerender = mid > 60
+
+                if (shouldTryRerender && (optFile == null || isOptInefficient)) {
+                    val rerender = tryFullRerender(context, tempFile, profile, {})
+                    if (rerender != null && (optFile == null || rerender.length() < optFile.length())) {
+                        optFile?.delete()
+                        optFile = rerender
+                        currentStrategy = CompressionStrategy.FULL_RERENDER
+                    } else {
+                        rerender?.delete()
+                    }
+                }
+
+                if (optFile != null) {
+                    val currentSize = optFile.length()
+
+                    if (currentSize <= targetSizeBytes) {
+                        // Success for this target size. We can try for better quality (lower mid)
+                        if (bestFile != null && bestFile != tempFile) bestFile.delete()
+                        bestFile = optFile
+                        bestQuality = mid
+                        bestSize = currentSize
+                        bestStrategy = currentStrategy
+                        high = mid - 1
+                    } else {
+                        // We need more compression (higher mid)
+                        if (bestFile == null || currentSize < bestSize) {
+                            // Keep it as a fallback in case we can't reach the target
+                            if (bestFile != null && bestFile != tempFile) bestFile.delete()
+                            bestFile = optFile
+                            bestSize = currentSize
+                            bestQuality = mid
+                            bestStrategy = currentStrategy
+                        } else {
+                            optFile.delete()
+                        }
+                        low = mid + 1
+                    }
+                } else {
+                    // Compression failed for this parameter, try more compression
+                    low = mid + 1
+                }
+            }
+
+            onProgress(0.95f)
+
+            if (bestFile != null) {
+                bestFile.inputStream().use { it.copyTo(outputStream) }
+                outputStream.flush()
+                onProgress(1.0f)
+
+                val isTargetReached = bestSize <= targetSizeBytes
+
+                return@withContext if (isTargetReached) {
+                    Result.success(
+                        CompressionResult(
+                            originalSize = originalSize,
+                            compressedSize = bestSize,
+                            compressionRatio = bestSize.toFloat() / originalSize,
+                            timeTakenMs = System.currentTimeMillis() - startTime,
+                            pagesProcessed = countPages(bestFile),
+                            strategyUsed = bestStrategy
+                        )
+                    )
+                } else {
+                    // Let the caller handle the failure or fallback
+                    Result.failure(
+                        TargetSizeNotReachedException(
+                            message = "Could not reach target size. Smallest possible size is ${bestSize} bytes.",
+                            smallestAchievableSize = bestSize,
+                            fallbackFile = bestFile,
+                            originalSize = originalSize,
+                            strategyUsed = bestStrategy,
+                            pagesProcessed = countPages(bestFile)
+                        )
+                    )
+                }
+            } else {
+                return@withContext Result.failure(IllegalStateException("Compression failed at all levels."))
+            }
+
+        } catch (e: Exception) {
+            return@withContext Result.failure(e)
+        } finally {
+            tempFile?.delete()
+            // Clean up any remaining iteration files in cacheDir that start with temp_target_compress or iter_
+            cacheDir.listFiles()?.forEach { file ->
+                if (file.name.startsWith("iter_") || file.name.startsWith("temp_target_compress_")) {
+                    file.delete()
+                }
+            }
+        }
+    }
+
     suspend fun compressPdf(
         context: Context,
         inputUri: Uri,
@@ -701,3 +868,13 @@ class PdfCompressor {
         )
     }
 }
+
+
+class TargetSizeNotReachedException(
+    message: String,
+    val smallestAchievableSize: Long,
+    val fallbackFile: File,
+    val originalSize: Long,
+    val strategyUsed: CompressionStrategy,
+    val pagesProcessed: Int
+) : Exception(message)

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/CompressScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/CompressScreen.kt
@@ -1,6 +1,5 @@
 package com.yourname.pdftoolkit.ui.screens
 import com.yourname.pdftoolkit.util.safeLaunch
-
 import androidx.compose.ui.res.stringResource
 import com.yourname.pdftoolkit.R
 
@@ -28,12 +27,19 @@ import com.yourname.pdftoolkit.data.OperationType
 import com.yourname.pdftoolkit.data.PdfFileInfo
 import com.yourname.pdftoolkit.domain.operations.CompressionLevel
 import com.yourname.pdftoolkit.domain.operations.PdfCompressor
+import com.yourname.pdftoolkit.domain.operations.TargetSizeNotReachedException
 import com.yourname.pdftoolkit.ui.components.*
 import com.yourname.pdftoolkit.util.FileOpener
 import com.yourname.pdftoolkit.util.OutputFolderManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+
+enum class CompressionMode {
+    LEVEL,
+    TARGET_SIZE
+}
 
 /**
  * Screen for compressing PDF files.
@@ -52,6 +58,10 @@ fun CompressScreen(
     // State
     var selectedFile by remember { mutableStateOf<PdfFileInfo?>(null) }
     var compressionSliderValue by remember { mutableStateOf(50f) }
+    var compressionMode by remember { mutableStateOf(CompressionMode.LEVEL) }
+    var targetSizeValue by remember { mutableStateOf("") }
+    var targetSizeUnit by remember { mutableStateOf("KB") }
+
     // Derive CompressionLevel from slider position
     val compressionLevel = when {
         compressionSliderValue < 25f -> CompressionLevel.LOW
@@ -95,14 +105,30 @@ fun CompressScreen(
                     
                     val outputStream = context.contentResolver.openOutputStream(outputUri)
                     if (outputStream != null) {
-                        val result = pdfCompressor.compressPdf(
-                            context = context,
-                            inputUri = file.uri,
-                            outputStream = outputStream,
-                            level = compressionLevel,
-                            qualityPercent = compressionSliderValue.toInt(),
-                            onProgress = { progress = it }
-                        )
+
+                        val result = if (compressionMode == CompressionMode.LEVEL) {
+                            pdfCompressor.compressPdf(
+                                context = context,
+                                inputUri = file.uri,
+                                outputStream = outputStream,
+                                level = compressionLevel,
+                                qualityPercent = compressionSliderValue.toInt(),
+                                onProgress = { progress = it }
+                            )
+                        } else {
+                            val targetBytes = targetSizeValue.toDoubleOrNull()?.let {
+                                (it * if (targetSizeUnit == "MB") 1024 * 1024 else 1024).toLong()
+                            } ?: 0L
+
+                            pdfCompressor.compressPdfToTargetSize(
+                                context = context,
+                                inputUri = file.uri,
+                                outputStream = outputStream,
+                                targetSizeBytes = targetBytes,
+                                onProgress = { progress = it }
+                            )
+                        }
+
                         
                         outputStream.close()
                         
@@ -144,8 +170,19 @@ fun CompressScreen(
                                 selectedFile = null
                             },
                             onFailure = { error ->
-                                resultSuccess = false
-                                resultMessage = error.message ?: "Compression failed"
+                                if (error is TargetSizeNotReachedException) {
+                                    resultSuccess = true
+                                    resultUri = copyToViewerCache(context, outputUri) ?: outputUri
+                                    resultMessage = buildString {
+                                        append("Target size not reached.\n\n")
+                                        append("Target: $targetSizeValue $targetSizeUnit\n")
+                                        append("Achieved: ${FileManager.formatFileSize(error.smallestAchievableSize)}\n\n")
+                                        append("Note: The file was compressed to the smallest possible size without destroying its contents.")
+                                    }
+                                } else {
+                                    resultSuccess = false
+                                    resultMessage = error.message ?: "Compression failed"
+                                }
                             }
                         )
                     } else {
@@ -173,14 +210,29 @@ fun CompressScreen(
                     val outputResult = OutputFolderManager.createOutputStream(context, fileName)
                     
                     if (outputResult != null) {
-                        val compressResult = pdfCompressor.compressPdf(
-                            context = context,
-                            inputUri = originalFile.uri,
-                            outputStream = outputResult.outputStream,
-                            level = compressionLevel,
-                            qualityPercent = compressionSliderValue.toInt(),
-                            onProgress = { progress = it }
-                        )
+                        val compressResult = if (compressionMode == CompressionMode.LEVEL) {
+                            pdfCompressor.compressPdf(
+                                context = context,
+                                inputUri = originalFile.uri,
+                                outputStream = outputResult.outputStream,
+                                level = compressionLevel,
+                                qualityPercent = compressionSliderValue.toInt(),
+                                onProgress = { progress = it }
+                            )
+                        } else {
+                            val targetBytes = targetSizeValue.toDoubleOrNull()?.let {
+                                (it * if (targetSizeUnit == "MB") 1024 * 1024 else 1024).toLong()
+                            } ?: 0L
+
+                            pdfCompressor.compressPdfToTargetSize(
+                                context = context,
+                                inputUri = originalFile.uri,
+                                outputStream = outputResult.outputStream,
+                                targetSizeBytes = targetBytes,
+                                onProgress = { progress = it }
+                            )
+                        }
+
                         
                         outputResult.outputStream.close()
                         
@@ -210,8 +262,19 @@ fun CompressScreen(
                                 Triple(true, message, outputResult.outputFile.contentUri)
                             },
                             onFailure = { error ->
-                                outputResult.outputFile.file.delete()
-                                Triple(false, error.message ?: "Compression failed", null)
+                                if (error is TargetSizeNotReachedException) {
+                                    val message = buildString {
+                                        append("Target size not reached.\n\n")
+                                        append("Target: $targetSizeValue $targetSizeUnit\n")
+                                        append("Achieved: ${FileManager.formatFileSize(error.smallestAchievableSize)}\n\n")
+                                        append("Note: The file was compressed to the smallest possible size without destroying its contents.\n\n")
+                                        append("Saved to: ${OutputFolderManager.getOutputFolderPath(context)}/${outputResult.outputFile.fileName}")
+                                    }
+                                    Triple(true, message, outputResult.outputFile.contentUri)
+                                } else {
+                                    outputResult.outputFile.file.delete()
+                                    Triple(false, error.message ?: "Compression failed", null)
+                                }
                             }
                         )
                     } else {
@@ -334,7 +397,7 @@ fun CompressScreen(
                             }
                         }
                         
-                        // Compression level slider
+                        // Compression options
                         item {
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
@@ -347,11 +410,29 @@ fun CompressScreen(
                                         .fillMaxWidth()
                                         .padding(16.dp)
                                 ) {
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                        verticalAlignment = Alignment.CenterVertically
+                                    TabRow(
+                                        selectedTabIndex = if (compressionMode == CompressionMode.LEVEL) 0 else 1,
+                                        containerColor = androidx.compose.ui.graphics.Color.Transparent,
+                                        modifier = Modifier.padding(bottom = 16.dp)
                                     ) {
+                                        Tab(
+                                            selected = compressionMode == CompressionMode.LEVEL,
+                                            onClick = { compressionMode = CompressionMode.LEVEL },
+                                            text = { Text("Compression Level") }
+                                        )
+                                        Tab(
+                                            selected = compressionMode == CompressionMode.TARGET_SIZE,
+                                            onClick = { compressionMode = CompressionMode.TARGET_SIZE },
+                                            text = { Text("Target Size") }
+                                        )
+                                    }
+
+                                    if (compressionMode == CompressionMode.LEVEL) {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.SpaceBetween,
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
                                         Text(
                                             text = "Compression Level",
                                             style = MaterialTheme.typography.titleSmall,
@@ -413,19 +494,90 @@ fun CompressScreen(
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     }
+                                } else {
+                                    OutlinedTextField(
+                                        value = targetSizeValue,
+                                        onValueChange = { newValue ->
+                                            if (newValue.isEmpty() || newValue.matches(Regex("^\\d*\\.?\\d*$"))) {
+                                                targetSizeValue = newValue
+                                            }
+                                        },
+                                        label = { Text("Target Size") },
+                                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                            keyboardType = androidx.compose.ui.text.input.KeyboardType.Number
+                                        ),
+                                        modifier = Modifier.fillMaxWidth(),
+                                        trailingIcon = {
+                                            var expanded by remember { mutableStateOf(false) }
+                                            Box {
+                                                TextButton(onClick = { expanded = true }) {
+                                                    Text(targetSizeUnit)
+                                                    Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                                                }
+                                                DropdownMenu(
+                                                    expanded = expanded,
+                                                    onDismissRequest = { expanded = false }
+                                                ) {
+                                                    DropdownMenuItem(
+                                                        text = { Text("KB") },
+                                                        onClick = { targetSizeUnit = "KB"; expanded = false }
+                                                    )
+                                                    DropdownMenuItem(
+                                                        text = { Text("MB") },
+                                                        onClick = { targetSizeUnit = "MB"; expanded = false }
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    )
+
+                                    Spacer(modifier = Modifier.height(8.dp))
+
+                                    val targetSizeBytes = targetSizeValue.toDoubleOrNull()?.let {
+                                        (it * if (targetSizeUnit == "MB") 1024 * 1024 else 1024).toLong()
+                                    }
+
+                                    val fileExceedsError = selectedFile != null && targetSizeBytes != null && targetSizeBytes >= selectedFile!!.size
+
+                                    if (fileExceedsError) {
+                                        Text(
+                                            text = "Target size must be less than original file size.",
+                                            color = MaterialTheme.colorScheme.error,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.height(12.dp))
+
+                                    // Quick select chips
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        val presets = listOf("50 KB", "100 KB", "200 KB", "500 KB", "1 MB")
+                                        presets.forEach { preset ->
+                                            val parts = preset.split(" ")
+                                            val value = parts[0]
+                                            val unit = parts[1]
+
+                                            FilterChip(
+                                                selected = targetSizeValue == value && targetSizeUnit == unit,
+                                                onClick = {
+                                                    targetSizeValue = value
+                                                    targetSizeUnit = unit
+                                                },
+                                                label = { Text(preset, style = MaterialTheme.typography.bodySmall) }
+                                            )
+                                        }
+                                    }
                                 }
+                            }
                             }
                         }
                         
                         // Estimated result
                         item {
-                            val estimatedSize = selectedFile?.let { file ->
-                                pdfCompressor.estimateCompressedSize(
-                                    file.size,
-                                    compressionSliderValue.toInt()
-                                )
-                            } ?: 0L
-                            
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
                                 colors = CardDefaults.cardColors(
@@ -445,17 +597,38 @@ fun CompressScreen(
                                     )
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Column {
-                                        Text(
-                                            text = "Estimated Result",
-                                            style = MaterialTheme.typography.labelLarge,
-                                            fontWeight = FontWeight.Medium,
-                                            color = MaterialTheme.colorScheme.onTertiaryContainer
-                                        )
-                                        Text(
-                                            text = "File size: ~${FileManager.formatFileSize(estimatedSize)}",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
-                                        )
+                                        if (compressionMode == CompressionMode.LEVEL) {
+                                            val estimatedSize = selectedFile?.let { file ->
+                                                pdfCompressor.estimateCompressedSize(
+                                                    file.size,
+                                                    compressionSliderValue.toInt()
+                                                )
+                                            } ?: 0L
+
+                                            Text(
+                                                text = "Estimated Result",
+                                                style = MaterialTheme.typography.labelLarge,
+                                                fontWeight = FontWeight.Medium,
+                                                color = MaterialTheme.colorScheme.onTertiaryContainer
+                                            )
+                                            Text(
+                                                text = "File size: ~${FileManager.formatFileSize(estimatedSize)}",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                                            )
+                                        } else {
+                                            Text(
+                                                text = "Target Size Optimization",
+                                                style = MaterialTheme.typography.labelLarge,
+                                                fontWeight = FontWeight.Medium,
+                                                color = MaterialTheme.colorScheme.onTertiaryContainer
+                                            )
+                                            Text(
+                                                text = "Will compress to the smallest quality needed to fit under ${targetSizeValue.ifEmpty { "X" }} $targetSizeUnit",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -522,6 +695,9 @@ fun CompressScreen(
                         ActionButton(
                             text = "Compress PDF",
                             onClick = {
+                                if (compressionMode == CompressionMode.TARGET_SIZE && targetSizeValue.isEmpty()) {
+                                    return@ActionButton
+                                }
                                 if (useCustomLocation) {
                                     val fileName = FileManager.generateOutputFileName("compressed")
                                     savePdfLauncher.safeLaunch(fileName, context)
@@ -530,6 +706,7 @@ fun CompressScreen(
                                 }
                             },
                             isLoading = isProcessing,
+                            enabled = if (compressionMode == CompressionMode.TARGET_SIZE) targetSizeValue.isNotEmpty() else true,
                             icon = Icons.Default.Compress
                         )
                     }

--- a/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfCompressorTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfCompressorTest.kt
@@ -25,6 +25,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.io.File
 import java.io.FileOutputStream
+import java.io.OutputStream
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], manifest = Config.NONE)
@@ -69,6 +70,67 @@ class PdfCompressorTest {
         val outputDoc = PDDocument.load(outputFile)
         assertEquals(1, outputDoc.numberOfPages)
         outputDoc.close()
+    }
+
+    @Test
+    fun testCompressPdfToTargetSize_Success() = runBlocking {
+        // Create a large PDF
+        val inputFile = File(context.cacheDir, "test_target_size.pdf")
+        createLargeTestPdf(inputFile, pages = 100)
+
+        val originalSize = inputFile.length()
+        // Given that it can reach 31609 bytes, lets use 40000 bytes
+        val targetSize = 40000L
+
+        val outputFile = File(context.cacheDir, "test_target_output.pdf")
+        val outputStream = FileOutputStream(outputFile)
+
+        val result = pdfCompressor.compressPdfToTargetSize(
+            context = context,
+            inputUri = Uri.fromFile(inputFile),
+            outputStream = outputStream,
+            targetSizeBytes = targetSize
+        )
+
+        outputStream.close()
+
+        if (result.isFailure) {
+            println("Error: " + result.exceptionOrNull()?.message)
+        }
+        assertTrue("Target size compression should succeed", result.isSuccess)
+
+        val compressionResult = result.getOrNull()!!
+        assertTrue(compressionResult.compressedSize <= targetSize)
+
+        val outputDoc = PDDocument.load(outputFile)
+        assertEquals(100, outputDoc.numberOfPages)
+        outputDoc.close()
+    }
+
+    @Test
+    fun testCompressPdfToTargetSize_Failure() = runBlocking {
+        val inputFile = File(context.cacheDir, "test_target_size_fail.pdf")
+        createTestPdf(inputFile)
+
+        // Extremely small target size impossible to reach
+        val targetSize = 10L
+
+        val outputFile = File(context.cacheDir, "test_target_output_fail.pdf")
+        val outputStream = FileOutputStream(outputFile)
+
+        val result = pdfCompressor.compressPdfToTargetSize(
+            context = context,
+            inputUri = Uri.fromFile(inputFile),
+            outputStream = outputStream,
+            targetSizeBytes = targetSize
+        )
+
+        outputStream.close()
+
+        assertTrue("Target size compression should fail with exception", result.isFailure)
+
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is TargetSizeNotReachedException)
     }
 
     @Test


### PR DESCRIPTION
Added Target Size compression option so users can specify a precise target file size they want the PDF compressed under (e.g. for exam form uploads).

---
*PR created automatically by Jules for task [7842451234864511494](https://jules.google.com/task/7842451234864511494) started by @Karna14314*