### PR TITLE
Feature: Per-Page PDF Rotation Support

### DIFF
--- a/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfRotator.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/domain/operations/PdfRotator.kt
@@ -2,6 +2,7 @@ package com.yourname.pdftoolkit.domain.operations
 
 import android.content.Context
 import android.net.Uri
+import com.tom_roush.pdfbox.io.MemoryUsageSetting
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -48,7 +49,7 @@ class PdfRotator {
                     IllegalStateException("Cannot open input file")
                 )
             
-            document = PDDocument.load(inputStream)
+            document = PDDocument.load(inputStream, MemoryUsageSetting.setupTempFileOnly())
             val totalPages = document.numberOfPages
             
             if (totalPages == 0) {
@@ -61,7 +62,7 @@ class PdfRotator {
                 ensureActive()
                 val page = document.getPage(pageIndex)
                 val currentRotation = page.rotation
-                val newRotation = (currentRotation + angle.degrees) % 360
+                val newRotation = ((currentRotation + angle.degrees) % 360 + 360) % 360
                 page.rotation = newRotation
                 
                 onProgress((pageIndex + 1).toFloat() / totalPages)
@@ -97,6 +98,27 @@ class PdfRotator {
         outputStream: OutputStream,
         rotations: Map<Int, RotationAngle>,
         onProgress: (Float) -> Unit = {}
+    ): Result<Int> {
+        val degreesMap = rotations.mapValues { it.value.degrees }
+        return rotateSpecificPagesWithDegrees(context, inputUri, outputStream, degreesMap, onProgress)
+    }
+
+    /**
+     * Rotate specific pages in a PDF using exact degree values.
+     *
+     * @param context Android context
+     * @param inputUri URI of the PDF to rotate
+     * @param outputStream Output stream for the rotated PDF
+     * @param rotations Map of page numbers (1-indexed) to rotation degrees (e.g. 90, 180, 270)
+     * @param onProgress Progress callback (0.0 to 1.0)
+     * @return Number of pages rotated
+     */
+    suspend fun rotateSpecificPagesWithDegrees(
+        context: Context,
+        inputUri: Uri,
+        outputStream: OutputStream,
+        rotations: Map<Int, Int>,
+        onProgress: (Float) -> Unit = {}
     ): Result<Int> = withContext(Dispatchers.IO) {
         var document: PDDocument? = null
         
@@ -106,7 +128,7 @@ class PdfRotator {
                     IllegalStateException("Cannot open input file")
                 )
             
-            document = PDDocument.load(inputStream)
+            document = PDDocument.load(inputStream, MemoryUsageSetting.setupTempFileOnly())
             val totalPages = document.numberOfPages
             
             // Validate page numbers
@@ -118,13 +140,22 @@ class PdfRotator {
             }
             
             var rotatedCount = 0
-            rotations.entries.forEachIndexed { index, (pageNum, angle) ->
+            if (rotations.isEmpty()) {
+                document.save(outputStream)
+                outputStream.flush()
+                return@withContext Result.success(0)
+            }
+
+            rotations.entries.forEachIndexed { index, (pageNum, degrees) ->
                 ensureActive()
-                val page = document.getPage(pageNum - 1) // 0-indexed
-                val currentRotation = page.rotation
-                val newRotation = (currentRotation + angle.degrees) % 360
-                page.rotation = newRotation
-                rotatedCount++
+                val normDegrees = ((degrees % 360) + 360) % 360
+                if (normDegrees != 0) {
+                    val page = document.getPage(pageNum - 1) // 0-indexed
+                    val currentRotation = page.rotation
+                    val newRotation = ((currentRotation + normDegrees) % 360 + 360) % 360
+                    page.rotation = newRotation
+                    rotatedCount++
+                }
                 
                 onProgress((index + 1).toFloat() / rotations.size)
             }

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/components/PdfThumbnailGrid.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/components/PdfThumbnailGrid.kt
@@ -64,7 +64,9 @@ fun PdfThumbnailGrid(
     displayPages: List<Int> = (1..pageCount).toList(),
     rotationDegrees: (Int) -> Float = { 0f },
     topLeftBadge: @Composable ((Int, Int) -> Unit)? = null, // (pageNum, index)
-    topRightBadge: @Composable ((Int, Int, Boolean) -> Unit)? = null // (pageNum, index, isSelected)
+    topRightBadge: @Composable ((Int, Int, Boolean) -> Unit)? = null, // (pageNum, index, isSelected)
+    bottomLeftBadge: @Composable ((Int, Int) -> Unit)? = null,
+    bottomRightBadge: @Composable ((Int, Int) -> Unit)? = null
 ) {
     val organizer = remember { PdfOrganizer() }
     val defaultTopLeft: @Composable (Int, Int) -> Unit = { pageNum, _ ->
@@ -106,6 +108,25 @@ fun PdfThumbnailGrid(
         }
     }
 
+    val defaultBottomRight: @Composable (Int, Int) -> Unit = { pageNum, _ ->
+        val deg = ((rotationDegrees(pageNum).toInt() % 360) + 360) % 360
+        if (deg != 0) {
+            Box(
+                modifier = Modifier
+                    .padding(6.dp)
+                    .background(Color.Black.copy(alpha = 0.75f), RoundedCornerShape(4.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "$deg°",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+
     LazyVerticalGrid(
         columns = GridCells.Fixed(columns),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -125,7 +146,9 @@ fun PdfThumbnailGrid(
                 onClick = { onPageSelected(selectionKey) },
                 rotationDegrees = rotationDegrees(pageNum),
                 topLeftBadge = { (topLeftBadge ?: defaultTopLeft)(pageNum, index) },
-                topRightBadge = { (topRightBadge ?: defaultTopRight)(pageNum, index, isSelected) }
+                topRightBadge = { (topRightBadge ?: defaultTopRight)(pageNum, index, isSelected) },
+                bottomLeftBadge = bottomLeftBadge?.let { { it(pageNum, index) } },
+                bottomRightBadge = { (bottomRightBadge ?: defaultBottomRight)(pageNum, index) }
             )
         }
     }
@@ -141,7 +164,9 @@ fun PdfThumbnailCard(
     modifier: Modifier = Modifier,
     rotationDegrees: Float = 0f,
     topLeftBadge: @Composable (() -> Unit)? = null,
-    topRightBadge: @Composable (() -> Unit)? = null
+    topRightBadge: @Composable (() -> Unit)? = null,
+    bottomLeftBadge: @Composable (() -> Unit)? = null,
+    bottomRightBadge: @Composable (() -> Unit)? = null
 ) {
     val context = LocalContext.current
     var thumbnail by remember { mutableStateOf<Bitmap?>(null) }
@@ -226,6 +251,18 @@ fun PdfThumbnailCard(
             if (topRightBadge != null) {
                 Box(modifier = Modifier.align(Alignment.TopEnd)) {
                     topRightBadge()
+                }
+            }
+
+            if (bottomLeftBadge != null) {
+                Box(modifier = Modifier.align(Alignment.BottomStart)) {
+                    bottomLeftBadge()
+                }
+            }
+
+            if (bottomRightBadge != null) {
+                Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+                    bottomRightBadge()
                 }
             }
         }

--- a/app/src/main/java/com/yourname/pdftoolkit/ui/screens/RotateScreen.kt
+++ b/app/src/main/java/com/yourname/pdftoolkit/ui/screens/RotateScreen.kt
@@ -1,8 +1,4 @@
 package com.yourname.pdftoolkit.ui.screens
-import com.yourname.pdftoolkit.util.safeLaunch
-
-import androidx.compose.ui.res.stringResource
-import com.yourname.pdftoolkit.R
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -11,36 +7,34 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import com.yourname.pdftoolkit.ui.components.PdfThumbnailGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.yourname.pdftoolkit.R
 import com.yourname.pdftoolkit.data.FileManager
 import com.yourname.pdftoolkit.data.HistoryManager
 import com.yourname.pdftoolkit.data.OperationType
 import com.yourname.pdftoolkit.data.PdfFileInfo
 import com.yourname.pdftoolkit.domain.operations.PdfRotator
 import com.yourname.pdftoolkit.domain.operations.PdfSplitter
-import com.yourname.pdftoolkit.domain.operations.RotationAngle
 import com.yourname.pdftoolkit.ui.components.*
 import com.yourname.pdftoolkit.util.FileOpener
 import com.yourname.pdftoolkit.util.OutputFolderManager
+import com.yourname.pdftoolkit.util.safeLaunch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
  * Screen for rotating PDF pages.
+ * Supports per-page custom rotation and batch operations (+90°, -90°, Reset).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,13 +45,17 @@ fun RotateScreen(
     val scope = rememberCoroutineScope()
     val pdfRotator = remember { PdfRotator() }
     val pdfSplitter = remember { PdfSplitter() }
-    
+
     // State
     var selectedFile by remember { mutableStateOf<PdfFileInfo?>(null) }
     var pageCount by remember { mutableStateOf(0) }
-    var rotationAngle by remember { mutableStateOf(RotationAngle.ROTATE_90) }
-    var rotateAllPages by remember { mutableStateOf(true) }
+
+    // Per-page rotation mapping: page number (1-indexed) -> added degrees (0, 90, 180, 270)
+    var pageRotations by remember { mutableStateOf<Map<Int, Int>>(emptyMap()) }
+
+    // Multi-selection state for batch actions
     var selectedPages by remember { mutableStateOf<Set<Int>>(emptySet()) }
+
     var isProcessing by remember { mutableStateOf(false) }
     var progress by remember { mutableStateOf(0f) }
     var showResult by remember { mutableStateOf(false) }
@@ -65,7 +63,7 @@ fun RotateScreen(
     var resultMessage by remember { mutableStateOf("") }
     var resultUri by remember { mutableStateOf<Uri?>(null) }
     var useCustomLocation by remember { mutableStateOf(false) }
-    
+
     // File picker launcher
     val pickPdfLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
@@ -74,13 +72,64 @@ fun RotateScreen(
             val fileInfo = FileManager.getFileInfo(context, uri)
             selectedFile = fileInfo
             selectedPages = emptySet()
-            
+            pageRotations = emptyMap()
+
             scope.launch {
                 pageCount = pdfSplitter.getPageCount(context, uri)
             }
         }
     }
-    
+
+    // Helper functions for rotation
+    fun rotatePage(pageNum: Int) {
+        val current = pageRotations[pageNum] ?: 0
+        val next = (current + 90) % 360
+        pageRotations = if (next == 0) {
+            pageRotations - pageNum
+        } else {
+            pageRotations + (pageNum to next)
+        }
+    }
+
+    fun rotateAllBy(deltaDegrees: Int) {
+        if (pageCount <= 0) return
+        val updated = pageRotations.toMutableMap()
+        for (p in 1..pageCount) {
+            val current = updated[p] ?: 0
+            val newDeg = ((current + deltaDegrees) % 360 + 360) % 360
+            if (newDeg == 0) {
+                updated.remove(p)
+            } else {
+                updated[p] = newDeg
+            }
+        }
+        pageRotations = updated
+    }
+
+    fun rotateSelectedBy(deltaDegrees: Int) {
+        if (selectedPages.isEmpty()) return
+        val updated = pageRotations.toMutableMap()
+        for (p in selectedPages) {
+            val current = updated[p] ?: 0
+            val newDeg = ((current + deltaDegrees) % 360 + 360) % 360
+            if (newDeg == 0) {
+                updated.remove(p)
+            } else {
+                updated[p] = newDeg
+            }
+        }
+        pageRotations = updated
+    }
+
+    fun resetAll() {
+        pageRotations = emptyMap()
+    }
+
+    fun resetSelected() {
+        if (selectedPages.isEmpty()) return
+        pageRotations = pageRotations - selectedPages
+    }
+
     // Save file launcher (for custom location)
     val savePdfLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/pdf")
@@ -90,34 +139,27 @@ fun RotateScreen(
             scope.launch {
                 isProcessing = true
                 progress = 0f
-                
+
                 val outputStream = context.contentResolver.openOutputStream(outputUri)
                 if (outputStream != null) {
-                    val result = if (rotateAllPages) {
-                        pdfRotator.rotateAllPages(
-                            context = context,
-                            inputUri = file.uri,
-                            outputStream = outputStream,
-                            angle = rotationAngle,
-                            onProgress = { progress = it }
-                        )
-                    } else {
-                        val rotations = selectedPages.associateWith { rotationAngle }
-                        pdfRotator.rotateSpecificPages(
-                            context = context,
-                            inputUri = file.uri,
-                            outputStream = outputStream,
-                            rotations = rotations,
-                            onProgress = { progress = it }
-                        )
-                    }
-                    
+                    val result = pdfRotator.rotateSpecificPagesWithDegrees(
+                        context = context,
+                        inputUri = file.uri,
+                        outputStream = outputStream,
+                        rotations = pageRotations,
+                        onProgress = { progress = it }
+                    )
+
                     outputStream.close()
-                    
+
                     result.fold(
                         onSuccess = { count ->
                             resultSuccess = true
-                            resultMessage = "Successfully rotated $count pages by ${rotationAngle.degrees}°"
+                            resultMessage = if (count > 0) {
+                                "Successfully applied rotation to $count pages"
+                            } else {
+                                "Saved PDF without changes"
+                            }
                             resultUri = outputUri
                         },
                         onFailure = { error ->
@@ -129,51 +171,49 @@ fun RotateScreen(
                     resultSuccess = false
                     resultMessage = "Cannot create output file"
                 }
-                
+
                 isProcessing = false
                 showResult = true
             }
         }
     }
-    
+
     // Function to rotate with default location
     fun rotateWithDefaultLocation() {
         scope.launch {
             isProcessing = true
             progress = 0f
             val originalFile = selectedFile!!
-            
+
             val result = withContext(Dispatchers.IO) {
                 try {
                     val fileName = FileManager.generateOutputFileName("rotated")
                     val outputResult = OutputFolderManager.createOutputStream(context, fileName)
-                    
+
                     if (outputResult != null) {
                         val file = selectedFile!!
-                        val rotateResult = if (rotateAllPages) {
-                            pdfRotator.rotateAllPages(
-                                context = context,
-                                inputUri = file.uri,
-                                outputStream = outputResult.outputStream,
-                                angle = rotationAngle,
-                                onProgress = { progress = it }
-                            )
-                        } else {
-                            val rotations = selectedPages.associateWith { rotationAngle }
-                            pdfRotator.rotateSpecificPages(
-                                context = context,
-                                inputUri = file.uri,
-                                outputStream = outputResult.outputStream,
-                                rotations = rotations,
-                                onProgress = { progress = it }
-                            )
-                        }
-                        
+                        val rotateResult = pdfRotator.rotateSpecificPagesWithDegrees(
+                            context = context,
+                            inputUri = file.uri,
+                            outputStream = outputResult.outputStream,
+                            rotations = pageRotations,
+                            onProgress = { progress = it }
+                        )
+
                         outputResult.outputStream.close()
-                        
+
                         rotateResult.fold(
                             onSuccess = { count ->
-                                Triple(true, "Successfully rotated $count pages by ${rotationAngle.degrees}°\n\nSaved to: ${OutputFolderManager.getOutputFolderPath(context)}/${outputResult.outputFile.fileName}", outputResult.outputFile.contentUri)
+                                val msg = if (count > 0) {
+                                    "Successfully applied rotation to $count pages"
+                                } else {
+                                    "Saved PDF without changes"
+                                }
+                                Triple(
+                                    true,
+                                    "$msg\n\nSaved to: ${OutputFolderManager.getOutputFolderPath(context)}/${outputResult.outputFile.fileName}",
+                                    outputResult.outputFile.contentUri
+                                )
                             },
                             onFailure = { error ->
                                 outputResult.outputFile.file.delete()
@@ -187,11 +227,11 @@ fun RotateScreen(
                     Triple(false, e.message ?: "Rotation failed", null)
                 }
             }
-            
+
             resultSuccess = result.first
             resultMessage = result.second
             resultUri = result.third
-            
+
             // Record in history
             if (resultSuccess && result.third != null) {
                 HistoryManager.recordSuccess(
@@ -200,7 +240,7 @@ fun RotateScreen(
                     inputFileName = originalFile.name,
                     outputFileUri = result.third,
                     outputFileName = "rotated_${originalFile.name}",
-                    details = "Rotated by ${rotationAngle.degrees}°"
+                    details = "Rotated ${pageRotations.size} pages"
                 )
             } else if (!resultSuccess) {
                 HistoryManager.recordFailure(
@@ -210,13 +250,12 @@ fun RotateScreen(
                     errorMessage = result.second
                 )
             }
-            
+
             isProcessing = false
             showResult = true
         }
     }
 
-    
     Scaffold(
         topBar = {
             ToolTopBar(
@@ -250,7 +289,7 @@ fun RotateScreen(
                             .padding(horizontal = 16.dp)
                     ) {
                         Spacer(modifier = Modifier.height(16.dp))
-                        
+
                         // Selected file info
                         Card(
                             modifier = Modifier.fillMaxWidth(),
@@ -283,9 +322,10 @@ fun RotateScreen(
                                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                                     )
                                 }
-                                IconButton(onClick = { 
+                                IconButton(onClick = {
                                     selectedFile = null
                                     selectedPages = emptySet()
+                                    pageRotations = emptyMap()
                                 }) {
                                     Icon(
                                         imageVector = Icons.Default.Close,
@@ -295,158 +335,166 @@ fun RotateScreen(
                                 }
                             }
                         }
-                        
-                        Spacer(modifier = Modifier.height(16.dp))
-                        
-                        // Rotation angle selection
-                        Text(
-                            text = "Rotation Angle",
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        
-                        Spacer(modifier = Modifier.height(8.dp))
-                        
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            RotationAngle.entries.forEach { angle ->
-                                RotationAngleChip(
-                                    angle = angle,
-                                    isSelected = rotationAngle == angle,
-                                    onClick = { rotationAngle = angle },
-                                    modifier = Modifier.weight(1f)
-                                )
-                            }
-                        }
-                        
-                        Spacer(modifier = Modifier.height(16.dp))
-                        
-                        // Rotate mode selection
-                        Text(
-                            text = "Pages to Rotate",
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        
-                        Spacer(modifier = Modifier.height(8.dp))
-                        
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            FilterChip(
-                                selected = rotateAllPages,
-                                onClick = { rotateAllPages = true },
-                                label = { Text(stringResource(R.string.rotate_all_pages)) },
-                                leadingIcon = if (rotateAllPages) {
-                                    { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                                } else null,
-                                modifier = Modifier.weight(1f)
-                            )
-                            
-                            FilterChip(
-                                selected = !rotateAllPages,
-                                onClick = { rotateAllPages = false },
-                                label = { Text(stringResource(R.string.rotate_select_pages)) },
-                                leadingIcon = if (!rotateAllPages) {
-                                    { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                                } else null,
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-                        
-                        Spacer(modifier = Modifier.height(16.dp))
-                        
-                        // Page selection (if not rotating all)
-                        if (!rotateAllPages) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = "Select Pages (${selectedPages.size})",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                
-                                TextButton(onClick = { selectedPages = emptySet() }) {
-                                    Text(stringResource(R.string.action_clear))
-                                }
-                            }
-                            
-                            Spacer(modifier = Modifier.height(8.dp))
-                            
-                            PdfThumbnailGrid(
-                                uri = selectedFile!!.uri,
-                                pageCount = pageCount,
-                                selectedPages = selectedPages,
-                                onPageSelected = { pageNum ->
-                                    selectedPages = if (pageNum in selectedPages) {
-                                        selectedPages - pageNum
-                                    } else {
-                                        selectedPages + pageNum
-                                    }
-                                },
-                                rotationDegrees = { pageNum ->
-                                    if (pageNum in selectedPages) {
-                                        when (rotationAngle) {
-                                            RotationAngle.ROTATE_90 -> 90f
-                                            RotationAngle.ROTATE_180 -> 180f
-                                            RotationAngle.ROTATE_270 -> 270f
-                                        }
-                                    } else {
-                                        0f
-                                    }
-                                },
-                                columns = 3,
-                                modifier = Modifier.fillMaxWidth().weight(1f)
-                            )
-                        } else {
-                            // "All Pages" preview block
-                            Spacer(modifier = Modifier.height(16.dp))
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // Batch Toolbar Controls
+                        Column(modifier = Modifier.fillMaxWidth()) {
                             Text(
-                                text = "Preview (First Page)",
-                                style = MaterialTheme.typography.labelLarge,
+                                text = if (selectedPages.isNotEmpty()) {
+                                    "Batch Actions (${selectedPages.size} selected)"
+                                } else {
+                                    "Batch Actions (All Pages)"
+                                },
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+
                             Spacer(modifier = Modifier.height(8.dp))
 
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .weight(1f),
-                                contentAlignment = Alignment.Center
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
-                                com.yourname.pdftoolkit.ui.components.PdfThumbnailCard(
-                                    uri = selectedFile!!.uri,
-                                    pageNumber = 1,
-                                    organizer = remember { com.yourname.pdftoolkit.domain.operations.PdfOrganizer() },
-                                    isSelected = true,
-                                    onClick = {},
-                                    rotationDegrees = when (rotationAngle) {
-                                        RotationAngle.ROTATE_90 -> 90f
-                                        RotationAngle.ROTATE_180 -> 180f
-                                        RotationAngle.ROTATE_270 -> 270f
+                                OutlinedButton(
+                                    onClick = {
+                                        if (selectedPages.isNotEmpty()) rotateSelectedBy(90) else rotateAllBy(90)
                                     },
-                                    modifier = Modifier.width(200.dp)
-                                )
+                                    modifier = Modifier.weight(1f),
+                                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.RotateRight,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text("+90°", style = MaterialTheme.typography.labelMedium)
+                                }
+
+                                OutlinedButton(
+                                    onClick = {
+                                        if (selectedPages.isNotEmpty()) rotateSelectedBy(-90) else rotateAllBy(-90)
+                                    },
+                                    modifier = Modifier.weight(1f),
+                                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.RotateLeft,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text("-90°", style = MaterialTheme.typography.labelMedium)
+                                }
+
+                                OutlinedButton(
+                                    onClick = {
+                                        if (selectedPages.isNotEmpty()) resetSelected() else resetAll()
+                                    },
+                                    modifier = Modifier.weight(1f),
+                                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Refresh,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text("Reset", style = MaterialTheme.typography.labelMedium)
+                                }
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // Header for Thumbnail Grid
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Tap thumbnail to rotate +90°",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                if (selectedPages.isNotEmpty()) {
+                                    TextButton(onClick = { selectedPages = emptySet() }) {
+                                        Text(stringResource(R.string.action_clear))
+                                    }
+                                }
+                                TextButton(onClick = {
+                                    selectedPages = if (selectedPages.size == pageCount) emptySet() else (1..pageCount).toSet()
+                                }) {
+                                    Text(if (selectedPages.size == pageCount) "Deselect All" else "Select All")
+                                }
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        // Thumbnail Grid
+                        PdfThumbnailGrid(
+                            uri = selectedFile!!.uri,
+                            pageCount = pageCount,
+                            selectedPages = selectedPages,
+                            onPageSelected = { pageNum ->
+                                // Tap rotates individual page directly
+                                rotatePage(pageNum)
+                            },
+                            topRightBadge = { pageNum, _, isSel ->
+                                Row(
+                                    modifier = Modifier.padding(4.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    // Multi-selection checkbox / icon button
+                                    IconButton(
+                                        onClick = {
+                                            selectedPages = if (pageNum in selectedPages) {
+                                                selectedPages - pageNum
+                                            } else {
+                                                selectedPages + pageNum
+                                            }
+                                        },
+                                        modifier = Modifier.size(28.dp)
+                                    ) {
+                                        Surface(
+                                            shape = androidx.compose.foundation.shape.CircleShape,
+                                            color = if (isSel) MaterialTheme.colorScheme.primary else androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.5f),
+                                            border = androidx.compose.foundation.BorderStroke(1.5.dp, androidx.compose.ui.graphics.Color.White),
+                                            modifier = Modifier.size(22.dp)
+                                        ) {
+                                            if (isSel) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Check,
+                                                    contentDescription = stringResource(R.string.cd_selected),
+                                                    tint = MaterialTheme.colorScheme.onPrimary,
+                                                    modifier = Modifier.padding(2.dp)
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            rotationDegrees = { pageNum ->
+                                (pageRotations[pageNum] ?: 0).toFloat()
+                            },
+                            columns = 3,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                        )
                     }
                 }
-                
-                // Progress overlay
+
                 // Progress overlay
                 if (isProcessing) {
-                    androidx.compose.animation.AnimatedVisibility(
-                        visible = true,
-                        enter = fadeIn(),
-                        exit = fadeOut(),
+                    Box(
                         modifier = Modifier.align(Alignment.Center)
                     ) {
                         Card(
@@ -469,10 +517,12 @@ fun RotateScreen(
                     }
                 }
             }
-            
+
             // Bottom action area
             Surface(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding(),
                 tonalElevation = 3.dp
             ) {
                 Column(
@@ -489,9 +539,14 @@ fun RotateScreen(
                             icon = Icons.Default.FolderOpen
                         )
                     } else {
-                        val pageText = if (rotateAllPages) "all pages" else "${selectedPages.size} pages"
+                        val modifiedCount = pageRotations.size
+                        val buttonText = if (modifiedCount > 0) {
+                            "Save PDF ($modifiedCount rotated)"
+                        } else {
+                            "Save PDF"
+                        }
                         ActionButton(
-                            text = "Rotate $pageText",
+                            text = buttonText,
                             onClick = {
                                 if (useCustomLocation) {
                                     val fileName = FileManager.generateOutputFileName("rotated")
@@ -500,7 +555,7 @@ fun RotateScreen(
                                     rotateWithDefaultLocation()
                                 }
                             },
-                            enabled = rotateAllPages || selectedPages.isNotEmpty(),
+                            enabled = true,
                             isLoading = isProcessing,
                             icon = Icons.Default.RotateRight
                         )
@@ -509,14 +564,14 @@ fun RotateScreen(
             }
         }
     }
-    
+
     // Result dialog with View option
     if (showResult) {
         ResultDialog(
             isSuccess = resultSuccess,
             title = if (resultSuccess) "Rotation Complete" else "Rotation Failed",
             message = resultMessage,
-            onDismiss = { 
+            onDismiss = {
                 showResult = false
                 resultUri = null
             },
@@ -527,59 +582,3 @@ fun RotateScreen(
         )
     }
 }
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun RotationAngleChip(
-    angle: RotationAngle,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        onClick = onClick,
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else {
-                MaterialTheme.colorScheme.surfaceVariant
-            }
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = when (angle) {
-                    RotationAngle.ROTATE_90 -> Icons.Default.RotateRight
-                    RotationAngle.ROTATE_180 -> Icons.Default.Sync
-                    RotationAngle.ROTATE_270 -> Icons.Default.RotateLeft
-                },
-                contentDescription = null,
-                tint = if (isSelected) {
-                    MaterialTheme.colorScheme.onPrimaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                }
-            )
-            
-            Spacer(modifier = Modifier.height(4.dp))
-            
-            Text(
-                text = "${angle.degrees}°",
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Bold,
-                color = if (isSelected) {
-                    MaterialTheme.colorScheme.onPrimaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                }
-            )
-        }
-    }
-}
-

--- a/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfRotatorTest.kt
+++ b/app/src/test/java/com/yourname/pdftoolkit/domain/operations/PdfRotatorTest.kt
@@ -1,0 +1,154 @@
+package com.yourname.pdftoolkit.domain.operations
+
+import android.content.Context
+import android.net.Uri
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
+import com.tom_roush.pdfbox.pdmodel.PDDocument
+import com.tom_roush.pdfbox.pdmodel.PDPage
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], manifest = Config.NONE)
+class PdfRotatorTest {
+
+    private lateinit var context: Context
+    private lateinit var pdfRotator: PdfRotator
+
+    @Before
+    fun setup() {
+        context = RuntimeEnvironment.getApplication()
+        PDFBoxResourceLoader.init(context)
+        pdfRotator = PdfRotator()
+        context.cacheDir.mkdirs()
+    }
+
+    private fun createTestPdf(file: File, pageCount: Int): Uri {
+        val document = PDDocument()
+        repeat(pageCount) {
+            document.addPage(PDPage())
+        }
+        document.save(file)
+        document.close()
+        return Uri.fromFile(file)
+    }
+
+    @Test
+    fun testRotateSpecificPagesWithDegrees() {
+        runBlocking {
+            val testFile = File(context.cacheDir, "rot_test.pdf")
+            val uri = createTestPdf(testFile, 5)
+
+            val outputFile = File(context.cacheDir, "rot_out.pdf")
+            val outputStream = FileOutputStream(outputFile)
+
+            // Rotate page 1 by 90°, page 3 by 180°, page 4 by 270°
+            val rotations = mapOf(
+                1 to 90,
+                3 to 180,
+                4 to 270
+            )
+
+            val result = pdfRotator.rotateSpecificPagesWithDegrees(
+                context = context,
+                inputUri = uri,
+                outputStream = outputStream,
+                rotations = rotations
+            )
+
+            outputStream.close()
+
+            assertTrue(result.isSuccess)
+            assertEquals(3, result.getOrNull())
+
+            // Verify rotations in generated PDF
+            val doc = PDDocument.load(outputFile)
+            assertEquals(5, doc.numberOfPages)
+            assertEquals(90, doc.getPage(0).rotation)
+            assertEquals(0, doc.getPage(1).rotation)
+            assertEquals(180, doc.getPage(2).rotation)
+            assertEquals(270, doc.getPage(3).rotation)
+            assertEquals(0, doc.getPage(4).rotation)
+            doc.close()
+
+            testFile.delete()
+            outputFile.delete()
+        }
+    }
+
+    @Test
+    fun testRotateAllPages() {
+        runBlocking {
+            val testFile = File(context.cacheDir, "rot_all_test.pdf")
+            val uri = createTestPdf(testFile, 3)
+
+            val outputFile = File(context.cacheDir, "rot_all_out.pdf")
+            val outputStream = FileOutputStream(outputFile)
+
+            val result = pdfRotator.rotateAllPages(
+                context = context,
+                inputUri = uri,
+                outputStream = outputStream,
+                angle = RotationAngle.ROTATE_180
+            )
+
+            outputStream.close()
+
+            assertTrue(result.isSuccess)
+            assertEquals(3, result.getOrNull())
+
+            val doc = PDDocument.load(outputFile)
+            assertEquals(180, doc.getPage(0).rotation)
+            assertEquals(180, doc.getPage(1).rotation)
+            assertEquals(180, doc.getPage(2).rotation)
+            doc.close()
+
+            testFile.delete()
+            outputFile.delete()
+        }
+    }
+
+    @Test
+    fun testRotateWithNegativeOrModuloDegrees() {
+        runBlocking {
+            val testFile = File(context.cacheDir, "rot_mod_test.pdf")
+            val uri = createTestPdf(testFile, 2)
+
+            val outputFile = File(context.cacheDir, "rot_mod_out.pdf")
+            val outputStream = FileOutputStream(outputFile)
+
+            val rotations = mapOf(
+                1 to -90, // equivalent to +270°
+                2 to 450  // equivalent to +90°
+            )
+
+            val result = pdfRotator.rotateSpecificPagesWithDegrees(
+                context = context,
+                inputUri = uri,
+                outputStream = outputStream,
+                rotations = rotations
+            )
+
+            outputStream.close()
+
+            assertTrue(result.isSuccess)
+
+            val doc = PDDocument.load(outputFile)
+            assertEquals(270, doc.getPage(0).rotation)
+            assertEquals(90, doc.getPage(1).rotation)
+            doc.close()
+
+            testFile.delete()
+            outputFile.delete()
+        }
+    }
+}

--- a/distribution/whatsnew/whatsnew-en-US
+++ b/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Updated Chinese translations for Portuguese and German language options.
+Added per-page PDF rotation support and batch rotation controls.


### PR DESCRIPTION
Redesigned the Rotate Pages tool to allow users to assign different rotation angles to different pages within the same operation.

### Changes Included:
1. **Per-Page State & UI Handling (`RotateScreen.kt`)**:
   - Replaced single global rotation angle state with `pageRotations: Map<Int, Int>` tracking modified pages.
   - Interactive thumbnail tapping: single tap advances rotation by +90° (0° -> 90° -> 180° -> 270° -> 0°).
   - Added batch controls for `+90°`, `-90°`, and `Reset` operating on selected pages or all pages.
   - Applied `Modifier.navigationBarsPadding()` to bottom action surface.

2. **Thumbnail Rendering & Badges (`PdfThumbnailGrid.kt`, `PdfThumbnailCard.kt`)**:
   - Added `bottomRightBadge` slot to display rotation angle indicators (`90°`, `180°`, `270°`) when rotated.
   - Real-time thumbnail preview updates in grid.

3. **Backend Engine (`PdfRotator.kt`)**:
   - Added `rotateSpecificPagesWithDegrees` method supporting arbitrary degree maps (0, 90, 180, 270) per 1-indexed page.
   - Configured `MemoryUsageSetting.setupTempFileOnly()` to prevent OOM errors on large PDFs.
   - Safe degree normalization and modulo handling for positive/negative rotations.

4. **Testing & Release Notes**:
   - Added unit tests in `PdfRotatorTest.kt`.
   - Updated Play Store release notes in `distribution/whatsnew/whatsnew-en-US`.

---
*PR created automatically by Jules for task [18385177565450207719](https://jules.google.com/task/18385177565450207719) started by @Karna14314*